### PR TITLE
Part 1: Securing /bridge_callbacks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ PATH
   remote: .
   specs:
     stellar_base-rails (0.1.2)
-      dry-struct
+      dry-types
       gem_config
+      httparty
       light-service
       rails (~> 5.1)
       trailblazer (~> 2.0)
       trailblazer-rails
+      virtus
 
 GEM
   remote: https://rubygems.org/
@@ -49,16 +51,28 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     builder (3.2.3)
     byebug (10.0.2)
     coderay (1.1.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     declarative (0.0.10)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     disposable (0.4.3)
       declarative (>= 0.0.9, < 1.0.0)
@@ -74,31 +88,29 @@ GEM
     dry-core (0.4.5)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.2.1)
+    dry-inflector (0.1.2)
     dry-logic (0.4.2)
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
-    dry-struct (0.4.0)
-      dry-core (~> 0.4, >= 0.4.1)
-      dry-equalizer (~> 0.2)
-      dry-types (~> 0.12, >= 0.12.2)
-      ice_nine (~> 0.11)
-    dry-types (0.12.2)
+    dry-types (0.13.0)
       concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.1)
       dry-container (~> 0.3)
-      dry-core (~> 0.2, >= 0.2.1)
+      dry-core (~> 0.4, >= 0.4.4)
       dry-equalizer (~> 0.2)
+      dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 0.4, >= 0.4.2)
-      inflecto (~> 0.0.0, >= 0.0.2)
+    equalizer (0.0.11)
     erubi (1.7.1)
     gem_config (0.3.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hashdiff (0.3.7)
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    inflecto (0.0.2)
     light-service (0.10.3)
       activesupport (>= 3.0)
     loofah (2.2.2)
@@ -110,6 +122,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    multi_xml (0.6.0)
     nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -120,6 +133,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
+    public_suffix (3.0.2)
     rack (2.0.5)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -174,6 +188,7 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    safe_yaml (1.0.4)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -200,6 +215,16 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
+    vcr (4.0.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+    webmock (3.4.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -212,6 +237,8 @@ DEPENDENCIES
   rspec-rails
   sqlite3
   stellar_base-rails!
+  vcr (~> 4.0)
+  webmock
 
 BUNDLED WITH
    1.16.1

--- a/README.md
+++ b/README.md
@@ -19,18 +19,39 @@ Create an initializer in your rails application:
 
 StellarBase.configure do |c|
   c.modules = %i(bridge_callbacks)
+  c.horizon_url = "https://horizon.stellar.org"
+
+  c.check_bridge_callbacks_authenticity = true
   c.on_bridge_callback = "StellarBridgeReceive::SaveTxn"
 end
 ```
 
+
 #### c.modules
+- Value(s): array of symbols
+  - bridge_callbacks - when supplied this will mount the `/bridge_callbacks` endpoint
+- Default: `%i(bridge_callbacks)`
 - You can supply what endpoints you want to activate with the gem
 - `bridge_callbacks` - this will mount a HTTP/S POST endpoint that acts as callback receiver for bridge server payments on the path. It will call your `.on_bridge_callback` class.
 
 #### c.on_bridge_callback
+- Value(s): Class
+- Default: None
 - Once the bridge_receive endpoint receives a callback, the class will be called with .call
 - The class will be passed with the bridge server callback payload contained in a `StellarBase::BridgeCallback` object.
 - The class will be expected to return a boolean, return true if the callback was processed properly
+- Warning: The bridge server will may post multiple callbacks with the same ID, make sure you handle these correctly. https://github.com/stellar/bridge-server/blob/master/readme_bridge.md#callbacksreceive
+
+
+#### c.check_bridge_callbacks_authenticity
+- Value(s): `true` or `false`
+- Default: `false`
+- This secures the `/bridge_callbacks` endpoint from fake transactions by checking the transaction ID and it's contents against the Stellar Blockchain. If it doesn't add up, `/bridge_callbacks` endpoint will respond with a 422
+
+#### c.horizon_url
+- Value(s): String, url to horizon
+- Default: https://horizon.stellar.org
+- This is where the engine will check bridge callbacks if `c.cross_reference_bridge_callback` is turned on
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,29 @@
 # Roadmap
 
-### 0.2.0
+### 0.2.x
+
+#### Securing /bridge_callbacks
+
+Implement application-level security measurements on securing the bridge_callbacks endpoint. Aside from the recommendation of Stellar to accept payloads coming from the Bridge Server IP, we can also do the following on this rails engine.
+
+1. Implementing checking payloads with the mac_key headers
+2. Implementing checking payloads with the api_key headers
+3. Another layer of defense, check authenticity of the callback by checking it against Horizon:
+  a. Existence of operation and transaction ID's against a Horizon instance
+  b. From, Amount, Issuer and other transaction details
+
+Number 3 can be implemented as follows:
+
+```
+  c.bridge_callbacks_authenticity = false
+  c.horizon_url = "https://horizon_url.com"
+```
+
+If `c.check_bridge_callbacks_authenticity` is set to `true`, it'll check incoming callbacks against a Horizon instance
+
+****
+
+### 0.3.0
 - Federation Endpoint
 ```
   c.modules = (federation)
@@ -15,7 +38,7 @@
 - The class will be expected to return a `StellarBase::FederationQueryResponse`, or you could return nil if no record is found.
 
 
-### 0.3.0
+### 0.4.0
 
 - Optionally mount a well-known
 

--- a/app/concepts/stellar_base/bridge_callbacks/contracts/process.rb
+++ b/app/concepts/stellar_base/bridge_callbacks/contracts/process.rb
@@ -14,6 +14,33 @@ module StellarBase
         property :data
         property :transaction_id
 
+        validate :check_callback_authenticity
+
+        def check_callback_authenticity
+          if !StellarBase.configuration.check_bridge_callbacks_authenticity
+            return
+          end
+
+          result = BridgeCallbacks::Check.({
+            operation_id: id,
+            transaction_id: transaction_id,
+            params: {
+              id: id,
+              from: from,
+              route: route,
+              amount: amount,
+              asset_code: asset_code,
+              asset_issuer: asset_issuer,
+              memo: memo,
+              memo_type: memo_type,
+              data: data,
+              transaction_id: transaction_id,
+            },
+          })
+
+          errors.add(:base, result.message) if result.failure?
+        end
+
       end
     end
   end

--- a/app/models/stellar_base/application_data_model.rb
+++ b/app/models/stellar_base/application_data_model.rb
@@ -1,9 +1,0 @@
-module StellarBase
-  module DryTypes
-    include Dry::Types.module
-  end
-
-  class ApplicationDataModel < Dry::Struct
-    constructor_type :schema
-  end
-end

--- a/app/models/stellar_base/bridge_callback.rb
+++ b/app/models/stellar_base/bridge_callback.rb
@@ -1,27 +1,17 @@
 module StellarBase
-  class BridgeCallback < ApplicationDataModel
+  class BridgeCallback
+    include Virtus.model
     # Attributes and params from
     # https://github.com/stellar/bridge-server/blob/master/readme_bridge.md#callbacksreceive
-    attribute :id, DryTypes::String.optional
-    attribute :from, DryTypes::String.optional
-    attribute :route, DryTypes::String.optional
-    attribute :amount, DryTypes::Decimal.optional
-    attribute :asset_code, DryTypes::String.optional
-    attribute :asset_issuer, DryTypes::String.optional
-    attribute :memo_type, DryTypes::String.optional
-    attribute :memo, DryTypes::String.optional
-    attribute :data, DryTypes::String.optional
-    attribute :transaction_id, DryTypes::String.optional
-
-    attr_writer :id
-    attr_writer :from
-    attr_writer :route
-    attr_writer :amount
-    attr_writer :asset_code
-    attr_writer :asset_issuer
-    attr_writer :memo_type
-    attr_writer :memo
-    attr_writer :data
-    attr_writer :transaction_id
+    attribute :id, String
+    attribute :from, String
+    attribute :route, String
+    attribute :amount, Float
+    attribute :asset_code, String
+    attribute :asset_issuer, String
+    attribute :memo_type, String
+    attribute :memo, String
+    attribute :data, String
+    attribute :transaction_id, String
   end
 end

--- a/app/services/stellar_base/bridge_callbacks/check.rb
+++ b/app/services/stellar_base/bridge_callbacks/check.rb
@@ -1,0 +1,16 @@
+module StellarBase
+  module BridgeCallbacks
+    class Check
+      extend LightService::Organizer
+
+      def self.call(opts = {})
+        with(opts).reduce(
+          InitializeHorizonClient,
+          GetOperation,
+          GetTransaction,
+        )
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/bridge_callbacks/get_operation.rb
+++ b/app/services/stellar_base/bridge_callbacks/get_operation.rb
@@ -1,0 +1,18 @@
+module StellarBase
+  module BridgeCallbacks
+    class GetOperation
+      extend LightService::Action
+      expects :operation_id, :client
+      promises :operation_response
+
+      executed do |c|
+        id = c.operation_id
+        response = c.client.get_operation(id)
+
+        c.fail_and_return! "Operation ##{id} doesn't exist" if !response.present?
+
+        c.operation_response = response
+      end
+    end
+  end
+end

--- a/app/services/stellar_base/bridge_callbacks/get_transaction.rb
+++ b/app/services/stellar_base/bridge_callbacks/get_transaction.rb
@@ -1,0 +1,21 @@
+module StellarBase
+  module BridgeCallbacks
+    class GetTransaction
+      extend LightService::Action
+      expects :client, :transaction_id
+      promises :transaction_response
+
+      executed do |c|
+        id = c.transaction_id
+        response = c.client.get_transaction(id)
+
+        if !response.present?
+          c.fail_and_return! "Transaction ##{id} doesn't exist"
+        end
+
+        c.transaction_response = response
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/bridge_callbacks/initialize_horizon_client.rb
+++ b/app/services/stellar_base/bridge_callbacks/initialize_horizon_client.rb
@@ -1,0 +1,13 @@
+module StellarBase
+  module BridgeCallbacks
+    class InitializeHorizonClient
+      extend LightService::Action
+
+      promises :client
+
+      executed do |c|
+        c.client = HorizonClient.new
+      end
+    end
+  end
+end

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -1,6 +1,7 @@
 require "gem_config"
 require "light-service"
-require "dry-struct"
+require "virtus"
+require "httparty"
 require "trailblazer-rails"
 require "disposable"
 require "reform"

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -12,6 +12,7 @@ module StellarBase
 
   with_configuration do
     has :modules, default: [:bridge_callbacks]
+    has :check_bridge_callbacks_authenticity, default: false
     has :on_bridge_callback
   end
 

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -6,12 +6,14 @@ require "trailblazer-rails"
 require "disposable"
 require "reform"
 require "reform/form/coercion"
+
 require "stellar_base/engine"
 
 module StellarBase
   include GemConfig::Base
 
   with_configuration do
+    has :horizon_url, default: "https://horizon.stellar.org"
     has :modules, default: [:bridge_callbacks]
     has :check_bridge_callbacks_authenticity, default: false
     has :on_bridge_callback
@@ -22,4 +24,4 @@ module StellarBase
   end
 end
 
-
+require "stellar_base/horizon_client"

--- a/lib/stellar_base/horizon_client.rb
+++ b/lib/stellar_base/horizon_client.rb
@@ -1,14 +1,24 @@
 module StellarBase
   class HorizonClient
     def get_operation(operation_id)
-      response = HTTParty.get(base_operations_path(operation_id))
+      response = HTTParty.get(horizon_operations_path(operation_id))
+
+      JSON.parse(response.body) if response.code == 200
+    end
+
+    def get_transaction(transaction_id)
+      response = HTTParty.get(horizon_transactions_path(transaction_id))
 
       JSON.parse(response.body) if response.code == 200
     end
 
     private
 
-    def base_operations_path(operation_id)
+    def horizon_transactions_path(transaction_id)
+      "#{base_url}/transactions/#{transaction_id}"
+    end
+
+    def horizon_operations_path(operation_id)
       "#{base_url}/operations/#{operation_id}"
     end
 

--- a/lib/stellar_base/horizon_client.rb
+++ b/lib/stellar_base/horizon_client.rb
@@ -1,0 +1,19 @@
+module StellarBase
+  class HorizonClient
+    def get_operation(operation_id)
+      response = HTTParty.get(base_operations_path(operation_id))
+
+      JSON.parse(response.body) if response.code == 200
+    end
+
+    private
+
+    def base_operations_path(operation_id)
+      "#{base_url}/operations/#{operation_id}"
+    end
+
+    def base_url
+      StellarBase.configuration.horizon_url
+    end
+  end
+end

--- a/spec/fixtures/bridge_callback.json
+++ b/spec/fixtures/bridge_callback.json
@@ -1,0 +1,12 @@
+{
+  "amount": "5.0000000",
+  "asset_code": "",
+  "asset_issuer": "",
+  "data": "",
+  "from": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+  "id": "37947582248411137",
+  "memo": "BX8F1E20BC4F5",
+  "memo_type": "text",
+  "route": "BX8F1E20BC4F5",
+  "transaction_id": "00ceef23ffcabf46c645827f87504311d8102f1806c714f788cddc23cd943ac8"
+}

--- a/spec/fixtures/operation.json
+++ b/spec/fixtures/operation.json
@@ -1,0 +1,30 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/operations/37587135708020737"
+    },
+    "transaction": {
+      "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/operations/37587135708020737/effects"
+    },
+    "succeeds": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=37587135708020737"
+    },
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=37587135708020737"
+    }
+  },
+  "id": "37587135708020737",
+  "paging_token": "37587135708020737",
+  "source_account": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+  "type": "payment",
+  "type_i": 1,
+  "created_at": "2018-05-02T11:25:57Z",
+  "transaction_hash": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+  "asset_type": "native",
+  "from": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+  "to": "GAIS4X5I2YBA2JHSESCYCDT7SKYBPTA5S22WAFHWOPTEMLRWD66GBQW2",
+  "amount": "200.0000000"
+}

--- a/spec/fixtures/transaction.json
+++ b/spec/fixtures/transaction.json
@@ -1,0 +1,45 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.bloomx.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+    },
+    "account": {
+      "href": "https://horizon-testnet.stellar.bloomx.org/accounts/GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT"
+    },
+    "ledger": {
+      "href": "https://horizon-testnet.stellar.bloomx.org/ledgers/8751437"
+    },
+    "operations": {
+      "href": "https://horizon-testnet.stellar.bloomx.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f/operations{?cursor,limit,order}",
+      "templated": true
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.bloomx.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f/effects{?cursor,limit,order}",
+      "templated": true
+    },
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.bloomx.org/transactions?order=asc\u0026cursor=37587135708020736"
+    },
+    "succeeds": {
+      "href": "https://horizon-testnet.stellar.bloomx.org/transactions?order=desc\u0026cursor=37587135708020736"
+    }
+  },
+  "id": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+  "paging_token": "37587135708020736",
+  "hash": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+  "ledger": 8751437,
+  "created_at": "2018-05-02T11:25:57Z",
+  "source_account": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+  "source_account_sequence": "37583802813382658",
+  "fee_paid": 100,
+  "operation_count": 1,
+  "envelope_xdr": "AAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAZACFhkUAAAACAAAAAAAAAAEAAAAJQlg4NTdEMTNFAAAAAAAAAQAAAAAAAAABAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAAAAAAAB3NZQAAAAAAAAAAAGQJAw0AAAAQLZNuyXv9ao/wupyYPvyUg3yYdTZvfqRSx5PHDAXpMqTIBI6m0gjn3wuUQF5yFebFLxQiNKFN7fNeYK4RHXylAY=",
+  "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+  "result_meta_xdr": "AAAAAAAAAAEAAAAEAAAAAwCFh+sAAAAAAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAADuaygAAhYfrAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCFiU0AAAAAAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAALLQXgAAhYfrAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwCFiU0AAAAAAAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAFwzcHTgAhYZFAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCFiU0AAAAAAAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAFpWmiTgAhYZFAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA",
+  "fee_meta_xdr": "AAAAAgAAAAMAhYfrAAAAAAAAAADdG++uuxN5YR493apEPVbNb9H1D20f4FvxwMlokCQMNAAAABcM3B2cAIWGRQAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAhYlNAAAAAAAAAADdG++uuxN5YR493apEPVbNb9H1D20f4FvxwMlokCQMNAAAABcM3B04AIWGRQAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+  "memo_type": "text",
+  "memo": "BX857D13E",
+  "signatures": [
+    "tk27Je/1qj/C6nJg+/JSDfJh1Nm9+pFLHk8cMBekypMgEjqbSCOffC5RAXnIV5sUvFCI0oU3t815grhEdfKUBg=="
+  ]
+}

--- a/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transaction/operation_doesn_t_exist/returns_422.yml
+++ b/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transaction/operation_doesn_t_exist/returns_422.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/operations/OPERATION_ID_1234
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 07 May 2018 08:57:25 GMT
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      Content-Length:
+      - '291'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=ddf64c478052cbb17a4a5c935108824d31525683445; expires=Tue, 07-May-19
+        08:57:25 GMT; path=/; domain=.stellar.org; HttpOnly
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17129'
+      X-Ratelimit-Reset:
+      - '1827'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41727aa0dac56d78-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "type": "https://stellar.org/horizon-errors/bad_request",
+          "title": "Bad Request",
+          "status": 400,
+          "detail": "The request you sent was invalid in some way",
+          "extras": {
+            "invalid_field": "id",
+            "reason": "strconv.ParseInt: parsing \"OPERATION_ID_1234\": invalid syntax"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 07 May 2018 08:57:25 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transaction/transaction_doesn_t_exist/returns_422.yml
+++ b/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transaction/transaction_doesn_t_exist/returns_422.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/operations/37587135708020737
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 07 May 2018 08:59:19 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '1149'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d1ed4930542a9381f64a9246b90ee112c1525683558; expires=Tue, 07-May-19
+        08:59:18 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17123'
+      X-Ratelimit-Reset:
+      - '1699'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41727d635dbf6dc6-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/operations/37587135708020737"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/operations/37587135708020737/effects"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=37587135708020737"
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=37587135708020737"
+            }
+          },
+          "id": "37587135708020737",
+          "paging_token": "37587135708020737",
+          "source_account": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "type": "payment",
+          "type_i": 1,
+          "created_at": "2018-05-02T11:25:57Z",
+          "transaction_hash": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          "asset_type": "native",
+          "from": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "to": "GAIS4X5I2YBA2JHSESCYCDT7SKYBPTA5S22WAFHWOPTEMLRWD66GBQW2",
+          "amount": "200.0000000"
+        }
+    http_version: 
+  recorded_at: Mon, 07 May 2018 08:59:19 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/TRANSACTION_ID_1234
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 07 May 2018 08:59:20 GMT
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      Content-Length:
+      - '325'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=df007808095c616a18c3b21eed5171cdb1525683559; expires=Tue, 07-May-19
+        08:59:19 GMT; path=/; domain=.stellar.org; HttpOnly
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17122'
+      X-Ratelimit-Reset:
+      - '1698'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41727d6928ba9699-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "type": "https://stellar.org/horizon-errors/not_found",
+          "title": "Resource Missing",
+          "status": 404,
+          "detail": "The resource at the url requested was not found.  This is usually occurs for one of two reasons:  The url requested is not valid, or no data in our database could be found with the parameters provided."
+        }
+    http_version: 
+  recorded_at: Mon, 07 May 2018 08:59:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_operation/existing_operation/returns_the_parsed_operation_object.yml
+++ b/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_operation/existing_operation/returns_the_parsed_operation_object.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/operations/37587135708020737
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 07 May 2018 09:11:26 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '1149'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d35423fcfeb97496b85be125db3af224f1525684286; expires=Tue, 07-May-19
+        09:11:26 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17101'
+      X-Ratelimit-Reset:
+      - '987'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41728f287e5b6ca0-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/operations/37587135708020737"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/operations/37587135708020737/effects"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=37587135708020737"
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=37587135708020737"
+            }
+          },
+          "id": "37587135708020737",
+          "paging_token": "37587135708020737",
+          "source_account": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "type": "payment",
+          "type_i": 1,
+          "created_at": "2018-05-02T11:25:57Z",
+          "transaction_hash": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          "asset_type": "native",
+          "from": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "to": "GAIS4X5I2YBA2JHSESCYCDT7SKYBPTA5S22WAFHWOPTEMLRWD66GBQW2",
+          "amount": "200.0000000"
+        }
+    http_version: 
+  recorded_at: Mon, 07 May 2018 09:11:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_operation/existing_transaction/returns_the_parsed_transaction_object.yml
+++ b/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_operation/existing_transaction/returns_the_parsed_transaction_object.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon.stellar.org/operations/37587135708020737
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      Date:
+      - Fri, 04 May 2018 13:23:46 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17199'
+      X-Ratelimit-Reset:
+      - '3599'
+      Content-Length:
+      - '325'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "type": "https://stellar.org/horizon-errors/not_found",
+          "title": "Resource Missing",
+          "status": 404,
+          "detail": "The resource at the url requested was not found.  This is usually occurs for one of two reasons:  The url requested is not valid, or no data in our database could be found with the parameters provided."
+        }
+    http_version: 
+  recorded_at: Fri, 04 May 2018 13:23:47 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/operations/37587135708020737
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 04 May 2018 13:24:57 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '1149'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d8156e7ba08d9e3a062c87dda33899cb51525440296; expires=Sat, 04-May-19
+        13:24:56 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17197'
+      X-Ratelimit-Reset:
+      - '3303'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 415b4a5fba6e6d78-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/operations/37587135708020737"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/operations/37587135708020737/effects"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=37587135708020737"
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=37587135708020737"
+            }
+          },
+          "id": "37587135708020737",
+          "paging_token": "37587135708020737",
+          "source_account": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "type": "payment",
+          "type_i": 1,
+          "created_at": "2018-05-02T11:25:57Z",
+          "transaction_hash": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          "asset_type": "native",
+          "from": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "to": "GAIS4X5I2YBA2JHSESCYCDT7SKYBPTA5S22WAFHWOPTEMLRWD66GBQW2",
+          "amount": "200.0000000"
+        }
+    http_version: 
+  recorded_at: Fri, 04 May 2018 13:24:57 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_operation/non-existent_operation/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_operation/non-existent_operation/returns_nil.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/operations/TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 07 May 2018 09:11:26 GMT
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dc359e70de6f558d252737fe540db1f991525684285; expires=Tue, 07-May-19
+        09:11:25 GMT; path=/; domain=.stellar.org; HttpOnly
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17088'
+      X-Ratelimit-Reset:
+      - '972'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41728f223bc66d72-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "type": "https://stellar.org/horizon-errors/bad_request",
+          "title": "Bad Request",
+          "status": 400,
+          "detail": "The request you sent was invalid in some way",
+          "extras": {
+            "invalid_field": "id",
+            "reason": "strconv.ParseInt: parsing \"TEST\": invalid syntax"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 07 May 2018 09:11:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_operation/non-existent_transcation/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_operation/non-existent_transcation/returns_nil.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/operations/TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Fri, 04 May 2018 13:24:55 GMT
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d259575eaa3661e1951cff3337e94a0ae1525440295; expires=Sat, 04-May-19
+        13:24:55 GMT; path=/; domain=.stellar.org; HttpOnly
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17198'
+      X-Ratelimit-Reset:
+      - '3305'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 415b4a55c8656d78-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "type": "https://stellar.org/horizon-errors/bad_request",
+          "title": "Bad Request",
+          "status": 400,
+          "detail": "The request you sent was invalid in some way",
+          "extras": {
+            "invalid_field": "id",
+            "reason": "strconv.ParseInt: parsing \"TEST\": invalid syntax"
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 04 May 2018 13:24:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_transaction/returns_the_parsed_transaction_object.yml
+++ b/spec/fixtures/vcr_cassettes/StellarBase_HorizonClient/_get_transaction/returns_the_parsed_transaction_object.yml
@@ -1,0 +1,98 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 07 May 2018 09:11:27 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2887'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dbb60b3dfdc03dbeac467285c741e8ebf1525684287; expires=Tue, 07-May-19
+        09:11:27 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17087'
+      X-Ratelimit-Reset:
+      - '970'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41728f2d4ef76c94-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+            },
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT"
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledgers/8751437"
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=37587135708020736"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=37587135708020736"
+            }
+          },
+          "id": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          "paging_token": "37587135708020736",
+          "hash": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          "ledger": 8751437,
+          "created_at": "2018-05-02T11:25:57Z",
+          "source_account": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "source_account_sequence": "37583802813382658",
+          "fee_paid": 100,
+          "operation_count": 1,
+          "envelope_xdr": "AAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAZACFhkUAAAACAAAAAAAAAAEAAAAJQlg4NTdEMTNFAAAAAAAAAQAAAAAAAAABAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAAAAAAAB3NZQAAAAAAAAAAAGQJAw0AAAAQLZNuyXv9ao/wupyYPvyUg3yYdTZvfqRSx5PHDAXpMqTIBI6m0gjn3wuUQF5yFebFLxQiNKFN7fNeYK4RHXylAY=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAAAAAAEAAAAEAAAAAwCFh+sAAAAAAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAADuaygAAhYfrAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCFiU0AAAAAAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAALLQXgAAhYfrAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwCFiU0AAAAAAAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAFwzcHTgAhYZFAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCFiU0AAAAAAAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAFpWmiTgAhYZFAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA",
+          "fee_meta_xdr": "AAAAAgAAAAMAhYfrAAAAAAAAAADdG++uuxN5YR493apEPVbNb9H1D20f4FvxwMlokCQMNAAAABcM3B2cAIWGRQAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAhYlNAAAAAAAAAADdG++uuxN5YR493apEPVbNb9H1D20f4FvxwMlokCQMNAAAABcM3B04AIWGRQAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "memo_type": "text",
+          "memo": "BX857D13E",
+          "signatures": [
+            "tk27Je/1qj/C6nJg+/JSDfJh1Nm9+pFLHk8cMBekypMgEjqbSCOffC5RAXnIV5sUvFCI0oU3t815grhEdfKUBg=="
+          ]
+        }
+    http_version: 
+  recorded_at: Mon, 07 May 2018 09:11:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/stellar_base/horizon_client_spec.rb
+++ b/spec/lib/stellar_base/horizon_client_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+module StellarBase
+  RSpec.describe HorizonClient, vcr: { record: :all } do
+    describe "#get_operation" do
+      context "non-existent transcation" do
+        it "returns nil" do
+          expect(described_class.new.get_operation("TEST")).to be_nil
+        end
+      end
+
+      context "existing transaction" do
+        it "returns the parsed transaction object" do
+          id = "37587135708020737"
+          result = described_class.new.get_operation(id)
+          expect(result).not_to be_nil
+          expect(result["id"]).to eq id
+        end
+      end
+
+    end
+  end
+end

--- a/spec/lib/stellar_base/horizon_client_spec.rb
+++ b/spec/lib/stellar_base/horizon_client_spec.rb
@@ -1,21 +1,31 @@
 require "spec_helper"
 
 module StellarBase
-  RSpec.describe HorizonClient, vcr: { record: :all } do
+  RSpec.describe HorizonClient, vcr: { record: :once } do
     describe "#get_operation" do
-      context "non-existent transcation" do
+      context "non-existent operation" do
         it "returns nil" do
           expect(described_class.new.get_operation("TEST")).to be_nil
         end
       end
 
-      context "existing transaction" do
-        it "returns the parsed transaction object" do
+      context "existing operation" do
+        it "returns the parsed operation object" do
           id = "37587135708020737"
           result = described_class.new.get_operation(id)
           expect(result).not_to be_nil
           expect(result["id"]).to eq id
         end
+      end
+
+    end
+
+    describe "#get_transaction" do
+      it "returns the parsed transaction object" do
+        id = "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+        result = described_class.new.get_transaction(id)
+        expect(result).not_to be_nil
+        expect(result["id"]).to eq id
       end
 
     end

--- a/spec/requests/bridge_callbacks_spec.rb
+++ b/spec/requests/bridge_callbacks_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "POST /bridge_callbacks", type: :request do
+describe "POST /bridge_callbacks", type: :request, vcr: { record: :once } do
   let(:uri) do
     StellarBase::Engine.routes.url_helpers.bridge_callbacks_path
   end
@@ -61,4 +61,63 @@ describe "POST /bridge_callbacks", type: :request do
       expect(response.code.to_i).to eq 422
     end
   end
+
+  context "fake transaction" do
+    before do
+      StellarBase.configure do |c|
+        c.check_bridge_callbacks_authenticity = true
+      end
+    end
+
+    after do
+      StellarBase.configure do |c|
+        c.check_bridge_callbacks_authenticity = false
+      end
+    end
+
+    context "operation doesn't exist" do
+      it "returns 422" do
+        params = {
+          id: "OPERATION_ID_1234",
+          from: "GABCSENDERXLMADDRESS",
+          route: "RECIPIENTROUTE",
+          amount: 100.00,
+          asset_code: "XLM",
+          asset_issuer: "GABCASSETISSUER",
+          memo_type: "id",
+          memo: "2",
+          data: "DATAHASH",
+          transaction_id: "TRANSACTION_ID_1234",
+        }
+
+        post uri, params: params
+
+        expect(response.success?).to eq false
+        expect(response.code.to_i).to eq 422
+      end
+    end
+
+    context "transaction doesn't exist" do
+      it "returns 422" do
+        params = {
+          id: "37587135708020737",
+          from: "GABCSENDERXLMADDRESS",
+          route: "RECIPIENTROUTE",
+          amount: 100.00,
+          asset_code: "XLM",
+          asset_issuer: "GABCASSETISSUER",
+          memo_type: "id",
+          memo: "2",
+          data: "DATAHASH",
+          transaction_id: "TRANSACTION_ID_1234",
+        }
+
+        post uri, params: params
+
+        expect(response.success?).to eq false
+        expect(response.code.to_i).to eq 422
+      end
+    end
+  end
+
 end

--- a/spec/services/stellar_base/bridge_callbacks/check_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/check_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    RSpec.describe Check do
+      it "calls a series of actions" do
+        actions = [
+          InitializeHorizonClient,
+          GetOperation,
+          GetTransaction,
+        ]
+
+        ctx = LightService::Context.new(
+          operation_id: "1234",
+          transaction_id: "1234",
+          params: {
+            id: "OPERATION_ID_1234",
+            from: "GABCSENDERXLMADDRESS",
+            route: "RECIPIENTROUTE",
+            amount: 100.00,
+            asset_code: "XLM",
+            asset_issuer: "GABCASSETISSUER",
+            memo_type: "id",
+            memo: "2",
+            data: "DATAHASH",
+            transaction_id: "TRANSACTION_ID_1234",
+          },
+        )
+
+        actions.each do |action|
+          expect(action).to receive(:execute).with(ctx).and_return(ctx)
+        end
+
+        described_class.({
+          operation_id: "1234",
+          transaction_id: "1234",
+          params: {
+            id: "OPERATION_ID_1234",
+            from: "GABCSENDERXLMADDRESS",
+            route: "RECIPIENTROUTE",
+            amount: 100.00,
+            asset_code: "XLM",
+            asset_issuer: "GABCASSETISSUER",
+            memo_type: "id",
+            memo: "2",
+            data: "DATAHASH",
+            transaction_id: "TRANSACTION_ID_1234",
+          },
+        })
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/bridge_callbacks/get_operation_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/get_operation_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    describe GetOperation do
+      let(:client) { double(HorizonClient) }
+      let(:id) { "1234" }
+
+      context "operation exists" do
+        let(:operation_json) { File.read(FIXTURES_DIR.join("operation.json")) }
+
+        it "returns an operation_json from Horizon" do
+          expect(client).to receive(:get_operation).with(id).and_return(
+            operation_json
+          )
+
+          result = described_class.execute(client: client, operation_id: id)
+
+          expect(result.operation_response).to eq operation_json
+        end
+      end
+
+      context "operation doesn't exist" do
+        it "fails the context" do
+          expect(client).to receive(:get_operation).with(id).and_return(nil)
+
+          result = described_class.execute(client: client, operation_id: id)
+
+          expect(result).to be_failure
+          expect(result.message).to eq "Operation #1234 doesn't exist"
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/services/stellar_base/bridge_callbacks/get_transaction_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/get_transaction_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    describe GetTransaction do
+      let(:client) { double(HorizonClient) }
+      let(:id) { "1234" }
+
+      context "transaction exists" do
+        let(:transaction_json) do
+          File.read(FIXTURES_DIR.join("transaction.json"))
+        end
+
+        it "returns a transaction_json from Horizon" do
+          expect(client).to receive(:get_transaction).with(id).and_return(
+            transaction_json
+          )
+
+          result = described_class.execute(client: client, transaction_id: id)
+
+          expect(result.transaction_response).to eq transaction_json
+        end
+      end
+
+      context "transaction doesn't exist" do
+        it "fails the context" do
+          expect(client).to receive(:get_transaction).with(id).and_return(nil)
+
+          result = described_class.execute(client: client, transaction_id: id)
+
+          expect(result).to be_failure
+          expect(result.message).to eq "Transaction #1234 doesn't exist"
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/services/stellar_base/bridge_callbacks/initialize_horizon_client_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/initialize_horizon_client_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    describe InitializeHorizonClient do
+      it "returns a HorizonClient instance" do
+        result = described_class.execute
+        expect(result.client).to be_a StellarBase::HorizonClient
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 ENV["RAILS_ENV"] = "test"
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "pry"
+require "vcr"
 require 'rspec/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc,

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -1,5 +1,7 @@
 StellarBase.configure do |c|
   c.modules = %i(bridge_callbacks)
+  c.check_bridge_callbacks_authenticity = false
+  c.horizon_url = "https://horizon-testnet.stellar.org"
   c.on_bridge_callback = "ProcessBridgeCallback"
 end
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,9 @@
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.ignore_localhost = true
+end
+
+
+

--- a/stellar_base.gemspec
+++ b/stellar_base.gemspec
@@ -16,14 +16,18 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "dry-struct"
+  s.add_dependency "virtus"
   s.add_dependency "gem_config"
   s.add_dependency "light-service"
   s.add_dependency "rails", "~> 5.1"
+  s.add_dependency "dry-types"
   s.add_dependency "trailblazer", "~> 2.0"
   s.add_dependency "trailblazer-rails"
+  s.add_dependency "httparty"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
+  s.add_development_dependency 'vcr', '~> 4.0'
+  s.add_development_dependency 'webmock'
 
 end


### PR DESCRIPTION
This is Part 1 of a series of Pull Requests that would implement securing bridge_callbacks.

1. Implementing checking payloads with the `mac_key` headers
2. Implementing checking payloads with the `api_key` headers
3. Another layer of defense, check authenticity of the callback by checking it against Horizon:
  a. Existence of operation and transaction ID's against a Horizon instance
  b. From, Amount, Issuer and other transaction details

This PR contains code for #3a