### PR TITLE
Part 2: Securing /bridge_callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.1]
+### Added
+- Added `BridgeCallbacks::Compare` step to check callback contents against operation/transaction details from Horizon
+
+## [0.2.0]
+### Added
+- Added `c.check_bridge_callbacks_authenticity` configuration option to flag security controls
+- Added `c.horizon_url` configuration
+- Added `StellarBase::BridgeCallbacks::Check` service to check callback authenticity against horizon
+
 ## [0.1.2]
 ### Changed
 - Moved `verify_authenticity_token` to `bridge_callbacks` controller

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,18 +1,15 @@
 # Roadmap
 
-### 0.2.x
-
-#### Securing /bridge_callbacks
+## Securing /bridge_callbacks
 
 Implement application-level security measurements on securing the bridge_callbacks endpoint. Aside from the recommendation of Stellar to accept payloads coming from the Bridge Server IP, we can also do the following on this rails engine.
 
-1. Implementing checking payloads with the mac_key headers
-2. Implementing checking payloads with the api_key headers
-3. Another layer of defense, check authenticity of the callback by checking it against Horizon:
+1. Implementing checking payloads with the `mac_key` headers
+2. Another layer of defense, check authenticity of the callback by checking it against Horizon:
   a. Existence of operation and transaction ID's against a Horizon instance
   b. From, Amount, Issuer and other transaction details
 
-Number 3 can be implemented as follows:
+Number 2 can be implemented as follows:
 
 ```
   c.bridge_callbacks_authenticity = false
@@ -23,7 +20,8 @@ If `c.check_bridge_callbacks_authenticity` is set to `true`, it'll check incomin
 
 ****
 
-### 0.3.0
+## /federation/queries
+
 - Federation Endpoint
 ```
   c.modules = (federation)
@@ -38,7 +36,7 @@ If `c.check_bridge_callbacks_authenticity` is set to `true`, it'll check incomin
 - The class will be expected to return a `StellarBase::FederationQueryResponse`, or you could return nil if no record is found.
 
 
-### 0.4.0
+## /.well-known
 
 - Optionally mount a well-known
 
@@ -73,3 +71,7 @@ if StellarBase.included_module?(:well_known)
   end
 end
 ```
+
+## rails g stellar_base:install
+
+- Convenience generator to automatically mount the engine to routes and to create an initializer template

--- a/app/concepts/stellar_base/bridge_callbacks/contracts/process.rb
+++ b/app/concepts/stellar_base/bridge_callbacks/contracts/process.rb
@@ -14,6 +14,11 @@ module StellarBase
         property :data
         property :transaction_id
 
+        validates :id, presence: true
+        validates :transaction_id, presence: true
+        validates :from, presence: true
+        validates :amount, presence: true
+
         validate :check_callback_authenticity
 
         def check_callback_authenticity

--- a/app/controllers/stellar_base/bridge_callbacks_controller.rb
+++ b/app/controllers/stellar_base/bridge_callbacks_controller.rb
@@ -10,6 +10,7 @@ module StellarBase
           if op.success?
             head :ok
           else
+            log_unsuccessful_callback(op)
             head :unprocessable_entity
           end
         end
@@ -17,6 +18,13 @@ module StellarBase
     end
 
     private
+
+    def log_unsuccessful_callback(op)
+      Rails.logger.warn("Unsuccessful bridge callback #{callback_params.to_s}")
+
+      error_messages = op["contract.default"].errors.full_messages
+      Rails.logger.warn("Details: #{error_messages}")
+    end
 
     def callback_params
       params.permit(

--- a/app/services/stellar_base/bridge_callbacks/check.rb
+++ b/app/services/stellar_base/bridge_callbacks/check.rb
@@ -8,6 +8,7 @@ module StellarBase
           InitializeHorizonClient,
           GetOperation,
           GetTransaction,
+          Compare,
         )
       end
 

--- a/app/services/stellar_base/bridge_callbacks/compare.rb
+++ b/app/services/stellar_base/bridge_callbacks/compare.rb
@@ -25,7 +25,7 @@ module StellarBase
 
         if result.any?
           message = [result.join(", "), "value isn't the same"].join(" ")
-        elsif transaction["id"] != operation["transaction_id"]
+        elsif transaction["id"] != operation["transaction_hash"]
           message = "Operation#transaction_id and transaction_id not the same"
         end
 

--- a/app/services/stellar_base/bridge_callbacks/compare.rb
+++ b/app/services/stellar_base/bridge_callbacks/compare.rb
@@ -1,0 +1,45 @@
+module StellarBase
+  module BridgeCallbacks
+    class Compare
+      extend LightService::Action
+      expects :operation_response, :transaction_response, :params
+
+      executed do |c|
+        operation = c.operation_response
+        transaction = c.transaction_response
+
+        # TODO: implement route check if Compliance server is available
+        hash = {
+          id: operation["id"],
+          from: operation["source_account"],
+          amount: operation["amount"],
+          route: transaction["memo"],
+          asset_code: transaction["asset_code"],
+          asset_issuer: transaction["asset_issuer"],
+          memo: transaction["memo"],
+          memo_type: transaction["memo_type"],
+          transaction_id: transaction["id"],
+        }
+
+        result = compare(hash, c.params)
+
+        if result.any?
+          message = [result.join(", "), "value isn't the same"].join(" ")
+        elsif transaction["id"] != operation["transaction_id"]
+          message = "Operation#transaction_id and transaction_id not the same"
+        end
+
+        c.fail_and_return! message if message.present?
+      end
+
+      def self.compare(hash, params)
+        # TODO: implement data comparison
+        params.except!(:data)
+
+        params.keys.map do |param_key|
+          param_key if params[param_key] != hash[param_key].to_s
+        end.compact
+      end
+    end
+  end
+end

--- a/app/services/stellar_base/bridge_callbacks/get_operation.rb
+++ b/app/services/stellar_base/bridge_callbacks/get_operation.rb
@@ -6,6 +6,8 @@ module StellarBase
       promises :operation_response
 
       executed do |c|
+        c.fail_and_return! unless c.operation_id.present?
+
         id = c.operation_id
         response = c.client.get_operation(id)
 

--- a/app/services/stellar_base/bridge_callbacks/get_transaction.rb
+++ b/app/services/stellar_base/bridge_callbacks/get_transaction.rb
@@ -6,6 +6,8 @@ module StellarBase
       promises :transaction_response
 
       executed do |c|
+        c.fail_and_return! unless c.transaction_id.present?
+
         id = c.transaction_id
         response = c.client.get_transaction(id)
 

--- a/spec/concepts/stellar_base/bridge_callbacks/contracts/process_spec.rb
+++ b/spec/concepts/stellar_base/bridge_callbacks/contracts/process_spec.rb
@@ -36,6 +36,16 @@ module StellarBase
 
         end
 
+        context "no id was submitted" do
+          it "returns errors" do
+            contract = described_class.new(BridgeCallback.new)
+            contract.validate({})
+
+            expect(contract.errors[:id])
+              .to include "can't be blank"
+          end
+        end
+
         context "if check_bridge_callbacks_authenticity is true" do
 
           before do

--- a/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transaction/callback_details_aren_t_the_same_with_existing_operation/transaction/returns_422.yml
+++ b/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transaction/callback_details_aren_t_the_same_with_existing_operation/transaction/returns_422.yml
@@ -1,0 +1,178 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/operations/37587135708020737
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 07 May 2018 10:45:13 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '1149'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dfe68e48022a20125e965bf486a576f871525689912; expires=Tue, 07-May-19
+        10:45:12 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17164'
+      X-Ratelimit-Reset:
+      - '2577'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4173188439c195ef-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/operations/37587135708020737"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/operations/37587135708020737/effects"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=37587135708020737"
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=37587135708020737"
+            }
+          },
+          "id": "37587135708020737",
+          "paging_token": "37587135708020737",
+          "source_account": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "type": "payment",
+          "type_i": 1,
+          "created_at": "2018-05-02T11:25:57Z",
+          "transaction_hash": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          "asset_type": "native",
+          "from": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "to": "GAIS4X5I2YBA2JHSESCYCDT7SKYBPTA5S22WAFHWOPTEMLRWD66GBQW2",
+          "amount": "200.0000000"
+        }
+    http_version: 
+  recorded_at: Mon, 07 May 2018 10:45:12 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 07 May 2018 10:45:14 GMT
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Content-Length:
+      - '2887'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=da7879059189872ca64994f2bb7e04e0c1525689913; expires=Tue, 07-May-19
+        10:45:13 GMT; path=/; domain=.stellar.org; HttpOnly
+      Content-Disposition:
+      - inline
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17155'
+      X-Ratelimit-Reset:
+      - '2622'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41731889cd429625-SJC
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f"
+            },
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT"
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledgers/8751437"
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=37587135708020736"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=37587135708020736"
+            }
+          },
+          "id": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          "paging_token": "37587135708020736",
+          "hash": "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          "ledger": 8751437,
+          "created_at": "2018-05-02T11:25:57Z",
+          "source_account": "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          "source_account_sequence": "37583802813382658",
+          "fee_paid": 100,
+          "operation_count": 1,
+          "envelope_xdr": "AAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAZACFhkUAAAACAAAAAAAAAAEAAAAJQlg4NTdEMTNFAAAAAAAAAQAAAAAAAAABAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAAAAAAAB3NZQAAAAAAAAAAAGQJAw0AAAAQLZNuyXv9ao/wupyYPvyUg3yYdTZvfqRSx5PHDAXpMqTIBI6m0gjn3wuUQF5yFebFLxQiNKFN7fNeYK4RHXylAY=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAAAAAAEAAAAEAAAAAwCFh+sAAAAAAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAADuaygAAhYfrAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCFiU0AAAAAAAAAABEuX6jWAg0k8iSFgQ5/krAXzB2WtWAU9nPmRi42H7xgAAAAALLQXgAAhYfrAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwCFiU0AAAAAAAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAFwzcHTgAhYZFAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQCFiU0AAAAAAAAAAN0b7667E3lhHj3dqkQ9Vs1v0fUPbR/gW/HAyWiQJAw0AAAAFpWmiTgAhYZFAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA",
+          "fee_meta_xdr": "AAAAAgAAAAMAhYfrAAAAAAAAAADdG++uuxN5YR493apEPVbNb9H1D20f4FvxwMlokCQMNAAAABcM3B2cAIWGRQAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAhYlNAAAAAAAAAADdG++uuxN5YR493apEPVbNb9H1D20f4FvxwMlokCQMNAAAABcM3B04AIWGRQAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "memo_type": "text",
+          "memo": "BX857D13E",
+          "signatures": [
+            "tk27Je/1qj/C6nJg+/JSDfJh1Nm9+pFLHk8cMBekypMgEjqbSCOffC5RAXnIV5sUvFCI0oU3t815grhEdfKUBg=="
+          ]
+        }
+    http_version: 
+  recorded_at: Mon, 07 May 2018 10:45:13 GMT
+recorded_with: VCR 4.0.0

--- a/spec/requests/bridge_callbacks_spec.rb
+++ b/spec/requests/bridge_callbacks_spec.rb
@@ -118,6 +118,28 @@ describe "POST /bridge_callbacks", type: :request, vcr: { record: :once } do
         expect(response.code.to_i).to eq 422
       end
     end
+
+    context "callback details aren't the same with existing operation/transaction" do
+      it "returns 422" do
+        params = {
+          id: "37587135708020737",
+          from: "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+          route: "BX857D13E",
+          amount: "200.0000000",
+          asset_code: "",
+          asset_issuer: "",
+          memo_type: "text",
+          memo: "BX857D13E",
+          data: "",
+          transaction_id: "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+        }
+
+        post uri, params: params
+
+        expect(response.success?).to eq false
+        expect(response.code.to_i).to eq 422
+      end
+    end
   end
 
 end

--- a/spec/services/stellar_base/bridge_callbacks/check_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/check_spec.rb
@@ -8,6 +8,7 @@ module StellarBase
           InitializeHorizonClient,
           GetOperation,
           GetTransaction,
+          Compare,
         ]
 
         ctx = LightService::Context.new(

--- a/spec/services/stellar_base/bridge_callbacks/compare_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/compare_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    RSpec.describe Compare do
+      let(:operation_json) { File.read(FIXTURES_DIR.join("operation.json")) }
+      let(:transaction_json) { File.read(FIXTURES_DIR.join("transaction.json")) }
+      let(:ctx) do
+        LightService::Context.new(
+          operation_response: JSON.parse(operation_json),
+          transaction_response: JSON.parse(transaction_json),
+          params: params,
+        )
+      end
+
+      context "callback isn't the same with horizon responses" do
+        let(:params) do
+          {
+            id: "37587135708020737",
+            from: "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+            route: "2",
+            amount: "200.0000000",
+            asset_code: "",
+            asset_issuer: "",
+            memo_type: "text",
+            memo: "2",
+            data: "",
+            transaction_id: "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          }
+        end
+
+        it "fails the context" do
+          result = described_class.execute(ctx)
+
+          expect(result).to be_failure
+          expect(result.message).to eq "route, memo value isn't the same"
+        end
+      end
+
+      context "callback is the same with horizon responses" do
+        let(:params) do
+          {
+            id: "37587135708020737",
+            from: "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+            route: "BX857D13E",
+            amount: "200.0000000",
+            asset_code: "",
+            asset_issuer: "",
+            memo_type: "text",
+            memo: "BX857D13E",
+            data: "",
+            transaction_id: "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          }
+        end
+
+        it "doesn't fail the context" do
+          result = described_class.execute(ctx)
+
+          expect(result).to be_success
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is Part 2 of a series of Pull Requests that would implement securing bridge_callbacks.

1. Implementing checking payloads with the mac_key headers
2. Another layer of defense, check authenticity of the callback by checking it against Horizon:
  a. Existence of operation and transaction ID's against a Horizon instance
  b. From, Amount, Issuer and other transaction details

This PR contains code for #2b