### PR TITLE
Part 3: Securing /bridge_callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.0]
+### Added
+- Added `c.check_bridge_callbacks_mac_payload` configuration option to flag if `/bridge_callbacks` will check for the `X_PAYLOAD_MAC` header that comes from the bridge server
+- Added `c.bridge_callbacks_mac_key` configuration
+- Added `StellarBase::BridgeCallbacks::VerifyMacPayload` service object to check if the callback is authentic
+
 ## [0.2.1]
 ### Added
 - Added `BridgeCallbacks::Compare` step to check callback contents against operation/transaction details from Horizon

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       httparty
       light-service
       rails (~> 5.1)
+      stellar-base (= 0.14.0)
       trailblazer (~> 2.0)
       trailblazer-rails
       virtus
@@ -58,6 +59,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    base32 (0.3.2)
     builder (3.2.3)
     byebug (10.0.2)
     coderay (1.1.2)
@@ -74,6 +76,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
+    digest-crc (0.4.1)
     disposable (0.4.3)
       declarative (>= 0.0.9, < 1.0.0)
       declarative-builder (< 0.2.0)
@@ -102,6 +105,7 @@ GEM
       dry-logic (~> 0.4, >= 0.4.2)
     equalizer (0.0.11)
     erubi (1.7.1)
+    ffi (1.9.23)
     gem_config (0.3.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -161,6 +165,10 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.1)
+    rbnacl (5.0.0)
+      ffi
+    rbnacl-libsodium (1.0.16)
+      rbnacl (>= 3.0.1)
     reform (2.2.4)
       disposable (>= 0.4.1)
       representable (>= 2.4.0, < 3.1.0)
@@ -197,6 +205,13 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    stellar-base (0.14.0)
+      activesupport (>= 4.2.7)
+      base32
+      digest-crc
+      rbnacl
+      rbnacl-libsodium (~> 1.0.3)
+      xdr (~> 2.0.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     trailblazer (2.0.7)
@@ -228,6 +243,9 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xdr (2.0.0)
+      activemodel (>= 4.2.7)
+      activesupport (>= 4.2.7)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ StellarBase.configure do |c|
   c.modules = %i(bridge_callbacks)
   c.horizon_url = "https://horizon.stellar.org"
 
-  c.check_bridge_callbacks_authenticity = true
   c.on_bridge_callback = "StellarBridgeReceive::SaveTxn"
+  c.check_bridge_callbacks_authenticity = true
+  c.check_bridge_callbacks_mac_payload = false
+  c.bridge_callbacks_mac_key = "test"
 end
 ```
 
@@ -33,6 +35,11 @@ end
 - Default: `%i(bridge_callbacks)`
 - You can supply what endpoints you want to activate with the gem
 - `bridge_callbacks` - this will mount a HTTP/S POST endpoint that acts as callback receiver for bridge server payments on the path. It will call your `.on_bridge_callback` class.
+
+#### c.horizon_url
+- Value(s): String, url to horizon
+- Default: https://horizon.stellar.org
+- This is where the engine will check bridge callbacks if `c.check_bridge_callbacks_authenticity` is turned on
 
 #### c.on_bridge_callback
 - Value(s): Class
@@ -48,10 +55,15 @@ end
 - Default: `false`
 - This secures the `/bridge_callbacks` endpoint from fake transactions by checking the transaction ID and it's contents against the Stellar Blockchain. If it doesn't add up, `/bridge_callbacks` endpoint will respond with a 422
 
-#### c.horizon_url
-- Value(s): String, url to horizon
-- Default: https://horizon.stellar.org
-- This is where the engine will check bridge callbacks if `c.cross_reference_bridge_callback` is turned on
+#### c.check_bridge_callbacks_mac_payload
+- Value(s): `true` or `false`
+- Default: `false`
+- This secures the `/bridge_callbacks` endpoint from fake transactions by checking the `X_PAYLOAD_MAC` header for 1.) existence and 2.) if it matches the HMAC-SH256 encoded raw request body
+
+#### c.bridge_callbacks_mac_key
+- Value(s): Any Stellar Private Key, it should be the same as the mac_key configured in your bridge server
+- Default: None
+- This is used to verify the contents of `X_PAYLOAD_MAC` by encoding the raw request body with the decoded `bridge_callback_mac_key` as the key
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/app/controllers/stellar_base/bridge_callbacks_controller.rb
+++ b/app/controllers/stellar_base/bridge_callbacks_controller.rb
@@ -40,5 +40,20 @@ module StellarBase
         :transaction_id,
       )
     end
+
+    def verify_mac_payload
+      callback_mac_payload = request.headers["HTTP_X_PAYLOAD_MAC"]
+
+      result = BridgeCallbacks::VerifyMacPayload.execute(
+        callback_params: callback_params,
+        callback_mac_payload: callback_mac_payload,
+      )
+
+      if result.failure?
+        log_unsuccessful_callback result.message
+        head :bad_request
+      end
+    end
+
   end
 end

--- a/app/services/stellar_base/bridge_callbacks/mac_payloads/check_payload.rb
+++ b/app/services/stellar_base/bridge_callbacks/mac_payloads/check_payload.rb
@@ -1,0 +1,17 @@
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+      class CheckPayload
+
+        extend LightService::Action
+        expects :callback_mac_payload
+
+        executed do |c|
+          unless c.callback_mac_payload.present?
+            c.fail_and_return! "HTTP_X_PAYLOAD_MAC not present"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/stellar_base/bridge_callbacks/mac_payloads/compare.rb
+++ b/app/services/stellar_base/bridge_callbacks/mac_payloads/compare.rb
@@ -1,0 +1,21 @@
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+      class Compare
+
+        extend LightService::Action
+        expects :encoded_params, :decoded_payload
+
+        executed do |c|
+          unless c.decoded_payload == c.encoded_params
+            message = "HTTP_X_PAYLOAD_MAC and encoded raw POST doesn't match"
+            c.fail_and_return! message
+          end
+
+          c.succeed!
+        end
+      end
+    end
+  end
+end
+

--- a/app/services/stellar_base/bridge_callbacks/mac_payloads/decode_mac_key.rb
+++ b/app/services/stellar_base/bridge_callbacks/mac_payloads/decode_mac_key.rb
@@ -1,0 +1,19 @@
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+      class DecodeMacKey
+
+        extend LightService::Action
+        promises :decoded_mac_key
+
+        executed do |c|
+          c.decoded_mac_key = Stellar::Util::StrKey.check_decode(
+            :seed,
+            StellarBase.configuration.bridge_callbacks_mac_key,
+          )
+        end
+      end
+    end
+  end
+end
+

--- a/app/services/stellar_base/bridge_callbacks/mac_payloads/decode_payload.rb
+++ b/app/services/stellar_base/bridge_callbacks/mac_payloads/decode_payload.rb
@@ -1,0 +1,17 @@
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+      class DecodePayload
+
+        extend LightService::Action
+        expects :callback_mac_payload
+        promises :decoded_payload
+
+        executed do |c|
+          c.decoded_payload = Base64.decode64(c.callback_mac_payload)
+        end
+      end
+    end
+  end
+end
+

--- a/app/services/stellar_base/bridge_callbacks/mac_payloads/encode_params.rb
+++ b/app/services/stellar_base/bridge_callbacks/mac_payloads/encode_params.rb
@@ -1,0 +1,21 @@
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+      class EncodeParams
+
+        extend LightService::Action
+        expects :callback_params, :decoded_mac_key
+        promises :encoded_params
+
+        executed do |c|
+          c.encoded_params = OpenSSL::HMAC.digest(
+            "SHA256",
+            c.decoded_mac_key,
+            c.callback_params.to_query,
+          )
+        end
+      end
+    end
+  end
+end
+

--- a/app/services/stellar_base/bridge_callbacks/verify_mac_payload.rb
+++ b/app/services/stellar_base/bridge_callbacks/verify_mac_payload.rb
@@ -1,0 +1,42 @@
+module StellarBase
+  module BridgeCallbacks
+    class VerifyMacPayload
+      extend LightService::Action
+      expects :callback_params, :callback_mac_payload
+
+      executed do |c|
+        callback_mac_payload = c.callback_mac_payload
+        callback_params = c.callback_params
+
+        unless callback_mac_payload.present?
+          c.fail_and_return! "X_PAYLOAD_MAC not present"
+        end
+
+        encoded_callback = encode_callback(callback_params)
+        decoded_payload = decode_payload(callback_mac_payload)
+
+        unless decoded_payload == encoded_callback
+          message = "X_PAYLOAD_MAC and encoded raw request body doesn't match"
+          c.fail_and_return! message
+        end
+
+        c.succeed!
+      end
+
+      private
+
+      def self.mac_key
+        StellarBase.configuration.bridge_callbacks_mac_key
+      end
+
+      def self.decode_payload(payload_mac)
+        Base64.decode64(payload_mac)
+      end
+
+      def self.encode_callback(callback_params)
+        OpenSSL::HMAC.digest("SHA256", mac_key, callback_params.to_json)
+      end
+    end
+  end
+end
+

--- a/app/services/stellar_base/bridge_callbacks/verify_mac_payload.rb
+++ b/app/services/stellar_base/bridge_callbacks/verify_mac_payload.rb
@@ -1,40 +1,19 @@
 module StellarBase
   module BridgeCallbacks
     class VerifyMacPayload
-      extend LightService::Action
-      expects :callback_params, :callback_mac_payload
+      extend LightService::Organizer
 
-      executed do |c|
-        callback_mac_payload = c.callback_mac_payload
-        callback_params = c.callback_params
-
-        unless callback_mac_payload.present?
-          c.fail_and_return! "X_PAYLOAD_MAC not present"
-        end
-
-        encoded_callback = encode_callback(callback_params)
-        decoded_payload = decode_payload(callback_mac_payload)
-
-        unless decoded_payload == encoded_callback
-          message = "X_PAYLOAD_MAC and encoded raw request body doesn't match"
-          c.fail_and_return! message
-        end
-
-        c.succeed!
-      end
-
-      private
-
-      def self.mac_key
-        StellarBase.configuration.bridge_callbacks_mac_key
-      end
-
-      def self.decode_payload(payload_mac)
-        Base64.decode64(payload_mac)
-      end
-
-      def self.encode_callback(callback_params)
-        OpenSSL::HMAC.digest("SHA256", mac_key, callback_params.to_json)
+      def self.call(callback_mac_payload:, callback_params:)
+        with(
+          callback_mac_payload: callback_mac_payload,
+          callback_params: callback_params,
+        ).reduce(
+          MacPayloads::CheckPayload,
+          MacPayloads::DecodePayload,
+          MacPayloads::DecodeMacKey,
+          MacPayloads::EncodeParams,
+          MacPayloads::Compare
+        )
       end
     end
   end

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -16,9 +16,11 @@ module StellarBase
   with_configuration do
     has :horizon_url, default: "https://horizon.stellar.org"
     has :modules, default: [:bridge_callbacks]
+
+    has :on_bridge_callback
     has :check_bridge_callbacks_authenticity, default: false
     has :check_bridge_callbacks_mac_payload, default: false
-    has :bridge_callbacks_mac_key
+    has :bridge_callbacks_mac_key, default: false
   end
 
   def self.included_module?(module_name)

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -1,4 +1,5 @@
 require "gem_config"
+require "stellar-base"
 require "light-service"
 require "virtus"
 require "httparty"
@@ -16,7 +17,8 @@ module StellarBase
     has :horizon_url, default: "https://horizon.stellar.org"
     has :modules, default: [:bridge_callbacks]
     has :check_bridge_callbacks_authenticity, default: false
-    has :on_bridge_callback
+    has :check_bridge_callbacks_mac_payload, default: false
+    has :bridge_callbacks_mac_key
   end
 
   def self.included_module?(module_name)

--- a/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transactions_are_being_posted/callback_details_aren_t_the_same_with_existing_operation/transaction/returns_422.yml
+++ b/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transactions_are_being_posted/callback_details_aren_t_the_same_with_existing_operation/transaction/returns_422.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 07 May 2018 10:45:13 GMT
+      - Mon, 07 May 2018 15:22:06 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
       Content-Length:
@@ -27,8 +27,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=dfe68e48022a20125e965bf486a576f871525689912; expires=Tue, 07-May-19
-        10:45:12 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=da370fcf0764b50dc609422628d4c560e1525706526; expires=Tue, 07-May-19
+        15:22:06 GMT; path=/; domain=.stellar.org; HttpOnly
       Content-Disposition:
       - inline
       Vary:
@@ -36,15 +36,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17164'
+      - '17115'
       X-Ratelimit-Reset:
-      - '2577'
+      - '1427'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 4173188439c195ef-SJC
+      - 4174ae1bdca193a8-SJC
     body:
       encoding: UTF-8
       string: |-
@@ -79,7 +79,7 @@ http_interactions:
           "amount": "200.0000000"
         }
     http_version: 
-  recorded_at: Mon, 07 May 2018 10:45:12 GMT
+  recorded_at: Mon, 07 May 2018 15:22:05 GMT
 - request:
     method: get
     uri: https://horizon-testnet.stellar.org/transactions/4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f
@@ -99,7 +99,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 07 May 2018 10:45:14 GMT
+      - Mon, 07 May 2018 15:22:07 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
       Content-Length:
@@ -107,8 +107,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=da7879059189872ca64994f2bb7e04e0c1525689913; expires=Tue, 07-May-19
-        10:45:13 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=d9d86b78ffb09aa9a79ff116ed999e0331525706527; expires=Tue, 07-May-19
+        15:22:07 GMT; path=/; domain=.stellar.org; HttpOnly
       Content-Disposition:
       - inline
       Vary:
@@ -116,15 +116,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17155'
+      - '17114'
       X-Ratelimit-Reset:
-      - '2622'
+      - '1427'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 41731889cd429625-SJC
+      - 4174ae228f66963d-SJC
     body:
       encoding: UTF-8
       string: |-
@@ -174,5 +174,5 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Mon, 07 May 2018 10:45:13 GMT
+  recorded_at: Mon, 07 May 2018 15:22:06 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transactions_are_being_posted/operation_doesn_t_exist/returns_422.yml
+++ b/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transactions_are_being_posted/operation_doesn_t_exist/returns_422.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Mon, 07 May 2018 08:57:25 GMT
+      - Mon, 07 May 2018 15:22:03 GMT
       Content-Type:
       - application/problem+json; charset=utf-8
       Content-Length:
@@ -27,22 +27,22 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=ddf64c478052cbb17a4a5c935108824d31525683445; expires=Tue, 07-May-19
-        08:57:25 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=de8461aaf910d508620d7e1ca050d6e5b1525706523; expires=Tue, 07-May-19
+        15:22:03 GMT; path=/; domain=.stellar.org; HttpOnly
       Vary:
       - Origin
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17129'
+      - '17119'
       X-Ratelimit-Reset:
-      - '1827'
+      - '1439'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 41727aa0dac56d78-SJC
+      - 4174ae0908a1963d-SJC
     body:
       encoding: UTF-8
       string: |-
@@ -57,5 +57,5 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 07 May 2018 08:57:25 GMT
+  recorded_at: Mon, 07 May 2018 15:22:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transactions_are_being_posted/transaction_doesn_t_exist/returns_422.yml
+++ b/spec/fixtures/vcr_cassettes/POST_/bridge_callbacks/fake_transactions_are_being_posted/transaction_doesn_t_exist/returns_422.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 07 May 2018 08:59:19 GMT
+      - Mon, 07 May 2018 15:22:04 GMT
       Content-Type:
       - application/hal+json; charset=utf-8
       Content-Length:
@@ -27,8 +27,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=d1ed4930542a9381f64a9246b90ee112c1525683558; expires=Tue, 07-May-19
-        08:59:18 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=dd206058f3b5ef4372a398a523b5d19111525706524; expires=Tue, 07-May-19
+        15:22:04 GMT; path=/; domain=.stellar.org; HttpOnly
       Content-Disposition:
       - inline
       Vary:
@@ -36,15 +36,15 @@ http_interactions:
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17123'
+      - '17118'
       X-Ratelimit-Reset:
-      - '1699'
+      - '1438'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 41727d635dbf6dc6-SJC
+      - 4174ae0f887a928e-SJC
     body:
       encoding: UTF-8
       string: |-
@@ -79,7 +79,7 @@ http_interactions:
           "amount": "200.0000000"
         }
     http_version: 
-  recorded_at: Mon, 07 May 2018 08:59:19 GMT
+  recorded_at: Mon, 07 May 2018 15:22:03 GMT
 - request:
     method: get
     uri: https://horizon-testnet.stellar.org/transactions/TRANSACTION_ID_1234
@@ -99,7 +99,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 07 May 2018 08:59:20 GMT
+      - Mon, 07 May 2018 15:22:05 GMT
       Content-Type:
       - application/problem+json; charset=utf-8
       Content-Length:
@@ -107,22 +107,22 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - __cfduid=df007808095c616a18c3b21eed5171cdb1525683559; expires=Tue, 07-May-19
-        08:59:19 GMT; path=/; domain=.stellar.org; HttpOnly
+      - __cfduid=d72341512a349528932a816963ab273481525706525; expires=Tue, 07-May-19
+        15:22:05 GMT; path=/; domain=.stellar.org; HttpOnly
       Vary:
       - Origin
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17122'
+      - '17116'
       X-Ratelimit-Reset:
-      - '1698'
+      - '1429'
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 41727d6928ba9699-SJC
+      - 4174ae16dd1493cc-SJC
     body:
       encoding: UTF-8
       string: |-
@@ -133,5 +133,5 @@ http_interactions:
           "detail": "The resource at the url requested was not found.  This is usually occurs for one of two reasons:  The url requested is not valid, or no data in our database could be found with the parameters provided."
         }
     http_version: 
-  recorded_at: Mon, 07 May 2018 08:59:20 GMT
+  recorded_at: Mon, 07 May 2018 15:22:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/requests/bridge_callbacks_spec.rb
+++ b/spec/requests/bridge_callbacks_spec.rb
@@ -62,7 +62,7 @@ describe "POST /bridge_callbacks", type: :request, vcr: { record: :once } do
     end
   end
 
-  context "fake transaction" do
+  context "fake transactions are being posted" do
     before do
       StellarBase.configure do |c|
         c.check_bridge_callbacks_authenticity = true
@@ -128,7 +128,7 @@ describe "POST /bridge_callbacks", type: :request, vcr: { record: :once } do
           amount: "200.0000000",
           asset_code: "",
           asset_issuer: "",
-          memo_type: "text",
+          memo_type: "id",
           memo: "BX857D13E",
           data: "",
           transaction_id: "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",

--- a/spec/requests/bridge_callbacks_spec.rb
+++ b/spec/requests/bridge_callbacks_spec.rb
@@ -142,4 +142,64 @@ describe "POST /bridge_callbacks", type: :request, vcr: { record: :once } do
     end
   end
 
+  context "X_PAYLOAD_MAC is configured to be checked" do
+    before do
+      StellarBase.configure do |c|
+        c.check_bridge_callbacks_mac_payload = true
+        c.bridge_callbacks_mac_key = "SDYOGCQL6HLTPZUDYDH7E3YST2AGZR3PJZXED62N42FJA6AWXDP3FSCA"
+      end
+    end
+
+    after do
+      StellarBase.configure do |c|
+        c.check_bridge_callbacks_mac_payload = false
+      end
+    end
+
+    let(:params) do
+      {
+        id: "37587135708020737",
+        from: "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+        route: "BX857D13E",
+        amount: "200.0000000",
+        asset_code: "",
+        asset_issuer: "",
+        memo_type: "text",
+        memo: "BX857D13E",
+        data: "",
+        transaction_id: "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+      }
+    end
+
+    let(:encoded_payload) do
+      payload = OpenSSL::HMAC.digest("SHA256", mac_key, params.to_json)
+      Base64.encode64(payload)
+    end
+
+    let(:headers) { { "HTTP_X_PAYLOAD_MAC" => encoded_payload } }
+
+    context "doesn't match" do
+      let(:mac_key) { "1234" }
+
+      it "renders 422" do
+        post uri, params: params, headers: headers
+
+        expect(response.success?).to eq false
+        expect(response.code).to eq "400"
+      end
+    end
+
+    context "it matches" do
+      let(:mac_key) { "SDYOGCQL6HLTPZUDYDH7E3YST2AGZR3PJZXED62N42FJA6AWXDP3FSCA" }
+
+      it "continues to process the payload" do
+        post uri, params: params, headers: headers
+
+        expect(response.success?).to eq true
+        expect(response.code).to eq "200"
+      end
+
+    end
+  end
+
 end

--- a/spec/services/stellar_base/bridge_callbacks/mac_payloads/check_payload_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/mac_payloads/check_payload_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+
+      RSpec.describe CheckPayload do
+        context "no mac_payload" do
+          it "fails the context" do
+            result = described_class.execute(callback_mac_payload: "")
+            expect(result).to be_failure
+            expect(result.message).to eq "HTTP_X_PAYLOAD_MAC not present"
+          end
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/services/stellar_base/bridge_callbacks/mac_payloads/compare_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/mac_payloads/compare_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+      RSpec.describe self::Compare do
+        context "params and payload doesn't match" do
+          it "fails the context and returns a message" do
+            result = described_class.execute(
+              encoded_params: "TEST",
+              decoded_payload: "TEST1",
+            )
+
+            expect(result).to be_failure
+            expect(result.message)
+              .to eq "HTTP_X_PAYLOAD_MAC and encoded raw POST doesn't match"
+          end
+        end
+
+        context "params and payload matches" do
+          it "succeeds the context" do
+            result = described_class.execute(
+              encoded_params: "TEST",
+              decoded_payload: "TEST",
+            )
+
+            expect(result.success?).to be true
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/bridge_callbacks/mac_payloads/decode_mac_key_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/mac_payloads/decode_mac_key_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+      RSpec.describe DecodeMacKey do
+        before do
+          StellarBase.configure do |c|
+            c.bridge_callbacks_mac_key = "SD4IMOHHYHZKVE3OF3DUAVZJDNYYNOYUB5DYFYKKVB6W36Y7EJ745TCN"
+          end
+        end
+
+        after do
+          StellarBase.configure do |c|
+            c.bridge_callbacks_mac_key = "test"
+          end
+        end
+
+        it "decodes the mac_key" do
+          expect(Stellar::Util::StrKey).to receive(:check_decode).with(
+            :seed,
+            "SD4IMOHHYHZKVE3OF3DUAVZJDNYYNOYUB5DYFYKKVB6W36Y7EJ745TCN"
+          ).and_return("decoded")
+
+          result = described_class.execute
+
+          expect(result.decoded_mac_key).to eq "decoded"
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/bridge_callbacks/mac_payloads/decode_payload_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/mac_payloads/decode_payload_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+
+      RSpec.describe DecodePayload do
+        it "returns the decoded payload" do
+          encoded_payload = Base64.encode64("TEST")
+
+          result = described_class.execute(callback_mac_payload: encoded_payload)
+
+          expect(result).to be_success
+          expect(result.decoded_payload).to eq "TEST"
+        end
+      end
+
+    end
+  end
+end

--- a/spec/services/stellar_base/bridge_callbacks/mac_payloads/encode_params_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/mac_payloads/encode_params_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    module MacPayloads
+      RSpec.describe EncodeParams do
+        let(:params) do
+          {
+            id: "37587135708020737",
+            from: "GDORX35OXMJXSYI6HXO2URB5K3GW7UPVB5WR7YC36HAMS2EQEQGDIRKT",
+            route: "BX857D13E",
+            amount: "200.0000000",
+            asset_code: "",
+            asset_issuer: "",
+            memo_type: "text",
+            memo: "BX857D13E",
+            data: "",
+            transaction_id: "4685b3b43512be87586832214da1d3ccd45c4098c2d90b8e3539866debe9652f",
+          }
+        end
+        let(:mac_key) { "TEST" }
+        let(:expected_encoded_params) do
+          OpenSSL::HMAC.digest("SHA256", mac_key, params.to_query)
+        end
+
+        it "encodes the current callback_params" do
+          result = described_class.execute(
+            callback_params: params,
+            decoded_mac_key: mac_key,
+          )
+
+          expect(result.encoded_params).to eq expected_encoded_params
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/bridge_callbacks/verify_mac_payload_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/verify_mac_payload_spec.rb
@@ -4,10 +4,32 @@ module StellarBase
   module BridgeCallbacks
     RSpec.describe VerifyMacPayload do
 
+      it "calls a series of actions" do
+        actions = [
+          MacPayloads::CheckPayload,
+          MacPayloads::DecodePayload,
+          MacPayloads::DecodeMacKey,
+          MacPayloads::EncodeParams,
+          MacPayloads::Compare
+        ]
+
+        ctx = LightService::Context.new(
+          callback_mac_payload: "TEST",
+          callback_params: "TEST",
+        )
+
+        actions.each do |action|
+          expect(action).to receive(:execute).with(ctx).and_return(ctx)
+        end
+
+        described_class.(callback_mac_payload: "TEST", callback_params: "TEST")
+      end
+
+
       before do
         StellarBase.configure do |c|
           c.check_bridge_callbacks_mac_payload = true
-          c.bridge_callbacks_mac_key = "TEST"
+          c.bridge_callbacks_mac_key = "SCGXDVN7C6M7SVLBICB4DBBMHD4VE3NUAQQYTZIGWZPOBC36JY3M4TKF"
         end
       end
 
@@ -35,24 +57,27 @@ module StellarBase
       let(:callback_mac_payload) do
         payload = OpenSSL::HMAC.digest(
           "SHA256",
-          mac_key,
-          callback_params.to_json,
+          decoded_mac_key,
+          callback_params.to_query,
         )
         Base64.encode64(payload)
       end
+      let(:decoded_mac_key) do
+        Stellar::Util::StrKey.check_decode(:seed, mac_key)
+      end
 
       context "doesn't match" do
-        let(:mac_key) { "1234" }
+        let(:mac_key) { "SDYOGCQL6HLTPZUDYDH7E3YST2AGZR3PJZXED62N42FJA6AWXDP3FSCA" }
 
         it "returns false" do
-          result = described_class.execute(
+          result = described_class.(
             callback_params: callback_params,
             callback_mac_payload: callback_mac_payload,
           )
 
           expect(result).to be_failure
 
-          message = "X_PAYLOAD_MAC and encoded raw request body doesn't match"
+          message = "HTTP_X_PAYLOAD_MAC and encoded raw POST doesn't match"
           expect(result.message).to eq message
         end
       end
@@ -61,7 +86,7 @@ module StellarBase
         let(:mac_key) { StellarBase.configuration.bridge_callbacks_mac_key }
 
         it "returns true" do
-          result = described_class.execute(
+          result = described_class.(
             callback_params: callback_params,
             callback_mac_payload: callback_mac_payload,
           )
@@ -72,13 +97,13 @@ module StellarBase
 
       context "no callback_mac_payload given" do
         it "returns false" do
-          result = described_class.execute(
+          result = described_class.(
             callback_params: callback_params,
             callback_mac_payload: "",
           )
 
           expect(result).to be_failure
-          expect(result.message).to eq "X_PAYLOAD_MAC not present"
+          expect(result.message).to eq "HTTP_X_PAYLOAD_MAC not present"
         end
 
       end

--- a/spec/services/stellar_base/bridge_callbacks/verify_mac_payload_spec.rb
+++ b/spec/services/stellar_base/bridge_callbacks/verify_mac_payload_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+module StellarBase
+  module BridgeCallbacks
+    RSpec.describe VerifyMacPayload do
+
+      before do
+        StellarBase.configure do |c|
+          c.check_bridge_callbacks_mac_payload = true
+          c.bridge_callbacks_mac_key = "TEST"
+        end
+      end
+
+      after do
+        StellarBase.configure do |c|
+          c.check_bridge_callbacks_mac_payload = false
+          c.bridge_callbacks_mac_key = "TEST"
+        end
+      end
+
+      let(:callback_params) do
+        {
+          id: "OPERATION_ID_1234",
+          from: "GABCSENDERXLMADDRESS",
+          route: "RECIPIENTROUTE",
+          amount: 100.00,
+          asset_code: "XLM",
+          asset_issuer: "GABCASSETISSUER",
+          memo_type: "id",
+          memo: "2",
+          data: "DATAHASH",
+          transaction_id: "TRANSACTION_ID_1234",
+        }
+      end
+      let(:callback_mac_payload) do
+        payload = OpenSSL::HMAC.digest(
+          "SHA256",
+          mac_key,
+          callback_params.to_json,
+        )
+        Base64.encode64(payload)
+      end
+
+      context "doesn't match" do
+        let(:mac_key) { "1234" }
+
+        it "returns false" do
+          result = described_class.execute(
+            callback_params: callback_params,
+            callback_mac_payload: callback_mac_payload,
+          )
+
+          expect(result).to be_failure
+
+          message = "X_PAYLOAD_MAC and encoded raw request body doesn't match"
+          expect(result.message).to eq message
+        end
+      end
+
+      context "it matches" do
+        let(:mac_key) { StellarBase.configuration.bridge_callbacks_mac_key }
+
+        it "returns true" do
+          result = described_class.execute(
+            callback_params: callback_params,
+            callback_mac_payload: callback_mac_payload,
+          )
+
+          expect(result).to be_success
+        end
+      end
+
+      context "no callback_mac_payload given" do
+        it "returns false" do
+          result = described_class.execute(
+            callback_params: callback_params,
+            callback_mac_payload: "",
+          )
+
+          expect(result).to be_failure
+          expect(result.message).to eq "X_PAYLOAD_MAC not present"
+        end
+
+      end
+    end
+  end
+end

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -1,8 +1,11 @@
 StellarBase.configure do |c|
   c.modules = %i(bridge_callbacks)
-  c.check_bridge_callbacks_authenticity = false
   c.horizon_url = "https://horizon-testnet.stellar.org"
+
   c.on_bridge_callback = "ProcessBridgeCallback"
+  c.check_bridge_callbacks_authenticity = false
+  c.check_bridge_callbacks_mac_payload = false
+  c.bridge_callbacks_mac_key = "sample"
 end
 
 

--- a/stellar_base.gemspec
+++ b/stellar_base.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "light-service"
   s.add_dependency "rails", "~> 5.1"
   s.add_dependency "dry-types"
+  s.add_dependency "stellar-base", "0.14.0"
   s.add_dependency "trailblazer", "~> 2.0"
   s.add_dependency "trailblazer-rails"
   s.add_dependency "httparty"


### PR DESCRIPTION
This is Part 2 of a series of Pull Requests that would implement securing bridge_callbacks.

1. Implementing checking payloads with the mac_key headers
2. Another layer of defense, check authenticity of the callback by checking it against Horizon:
  a. Existence of operation and transaction ID's against a Horizon instance
  b. From, Amount, Issuer and other transaction details

This PR contains code for #1