### PR TITLE
Developers can mount a stellar.toml endpoint

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+export PATH=./bin:$PATH
+
+FILE=.envrc.local && test -f $FILE && source $FILE
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/dummy/log/*.log
 spec/dummy/tmp/
 spec/config.yml
 tmp
+.rubocop.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Add capability for mounting `/.well-known` using a route helper: `mount_stellar_base_well_known`
+
 ## [0.4.1]
 ### Added
 - Show errors when unable to create withdraw request

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in stellar_base.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
@@ -11,4 +11,6 @@ gemspec
 # your gem to rubygems.org.
 
 # To use a debugger
-gem 'pry-byebug', group: [:development, :test]
+gem "pry-byebug", group: %i[development test]
+gem "spring"
+gem "spring-commands-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,10 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     safe_yaml (1.0.4)
+    spring (2.0.2)
+      activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -294,6 +298,8 @@ DEPENDENCIES
   factory_bot_rails
   pry-byebug
   rspec-rails
+  spring
+  spring-commands-rspec
   sqlite3
   stellar-sdk
   stellar_base-rails!
@@ -301,4 +307,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Adding modules to your routes:
 
 ```
 mount StellarBase::Engine => "/stellar"
+
+# Optionally, you can mount /.well-known/stellar
+mount_stellar_base_well_known
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ When building Rails apps, we’d always implement /.well-known/stellar and other
 Adding modules to your routes:
 
 ```
-mount StellarBase::Engine => "/stellar_base"
+mount StellarBase::Engine => "/stellar"
 ```
 
 ```sh
@@ -33,7 +33,6 @@ StellarBase.configure do |c|
 end
 ```
 
-
 #### c.modules
 You can supply what endpoints you want to activate with the gem
 
@@ -50,6 +49,23 @@ This is the same distribution account that is setup in bridge. Currently, it is 
 - Default: https://horizon.stellar.org
 - This is where the engine will check bridge callbacks if `c.check_bridge_callbacks_authenticity` is turned on
 
+### c.stellar_toml
+- Value(s): Hash, follow Stellar's [documentation](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) for `stellar.toml`
+- Example:
+```
+c.stellar_toml = {
+  TRANSFER_SERVER: ...,
+  FEDERATION_SERVER: ...,
+  AUTH_SERVER: ...,
+}
+```
+- Default:
+```
+c.stellar_toml = {
+  TRANSFER_SERVER: # if withdraw module is set, this is automatically set to the withdraw_endpoint unless overridden
+}
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 
@@ -62,13 +78,21 @@ And then execute:
 $ bundle
 ```
 
-## Contributing
+## Development
 
 ```ruby
 cp spec/config.yml{.sample,}
 ```
 
 Edit the `spec/config.yml` file.
+
+```sh
+cd spec/dummy
+rails db:migrate
+rails db:migrate RAILS_ENV=test
+```
+
+Now you can run `rspec spec`
 
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/app/controllers/stellar_base/home_controller.rb
+++ b/app/controllers/stellar_base/home_controller.rb
@@ -1,0 +1,24 @@
+module StellarBase
+  class HomeController < ApplicationController
+
+    before_action :set_cors_headers, only: %i[show]
+    skip_before_action :verify_authenticity_token
+
+    def show
+      stellar_toml = StellarToml.new(StellarBase.configuration.stellar_toml)
+
+      respond_to do |f|
+        f.toml do
+          render plain: TomlRB.dump(stellar_toml.to_hash)
+        end
+      end
+    end
+
+    private
+
+    def set_cors_headers
+      response.headers["Access-Control-Allow-Origin"] = "*"
+    end
+
+  end
+end

--- a/app/models/stellar_base/stellar_toml.rb
+++ b/app/models/stellar_base/stellar_toml.rb
@@ -1,0 +1,16 @@
+module StellarBase
+  class StellarToml
+
+    include Virtus.model
+
+    attribute(:TRANSFER_SERVER, String, {
+      lazy: true, default: :default_transfer_server
+    })
+
+    def default_transfer_server
+      return "" unless StellarBase.included_module?(:withdraw)
+      StellarBase::Engine.routes.url_helpers.withdraw_url
+    end
+
+  end
+end

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+require "pathname"
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path(
+  "../../Gemfile", Pathname.new(__FILE__).realpath
+)
+
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("rspec-core", "rspec")

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,0 +1,3 @@
+if Mime::Type.lookup("toml").blank?
+  Mime::Type.register "application/toml", :toml
+end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,0 @@
-if Mime::Type.lookup("toml").blank?
-  Mime::Type.register "application/toml", :toml
-end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,0 +1,1 @@
+Spring.application_root = "./spec/dummy"

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -28,6 +28,8 @@ module StellarBase
 
     has :withdrawable_assets, classes: [NilClass, Array, String, Pathname]
     has :on_withdraw
+
+    has :stellar_toml, classes: Hash
   end
 
   after_configuration_change do
@@ -58,7 +60,7 @@ module StellarBase
     YAML.load_file(str.to_s)
   rescue Errno::ENOENT
   end
-
 end
 
 require "stellar_base/horizon_client"
+require "stellar_base/rails/routes"

--- a/lib/stellar_base/engine.rb
+++ b/lib/stellar_base/engine.rb
@@ -1,10 +1,16 @@
 module StellarBase
   class Engine < ::Rails::Engine
+
     isolate_namespace StellarBase
 
     config.to_prepare do
       Engine.routes.default_url_options =
         Rails.application.routes.default_url_options
+    end
+
+    initializer "register.mime_types" do
+      return if Mime::Type.lookup_by_extension("toml").present?
+      Mime::Type.register "application/toml", :toml
     end
 
     config.generators do |g|

--- a/lib/stellar_base/rails/routes.rb
+++ b/lib/stellar_base/rails/routes.rb
@@ -1,0 +1,15 @@
+module ActionDispatch
+  module Routing
+    class Mapper
+
+      def mount_stellar_base_well_known
+        get(
+          "/.well-known/stellar" => "stellar_base/home#show",
+          :as => :stellar_toml,
+          :defaults => { format: "toml" },
+        )
+      end
+
+    end
+  end
+end

--- a/spec/dummy/bin/rake
+++ b/spec/dummy/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/spec/dummy/bin/rspec
+++ b/spec/dummy/bin/rspec
@@ -4,6 +4,5 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/spec/dummy/bin/spring
+++ b/spec/dummy/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,18 +1,20 @@
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
+require "rails/all"
 
 Bundler.require(*Rails.groups)
 require "stellar_base"
 
 module Dummy
   class Application < Rails::Application
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    Rails.application.routes.default_url_options[:host] = "example.com"
+
   end
 end
-

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   mount StellarBase::Engine => "/stellar_base"
+  mount_stellar_base_well_known
 end

--- a/spec/models/stellar_base/steller_toml_spec.rb
+++ b/spec/models/stellar_base/steller_toml_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+module StellarBase
+  RSpec.describe StellarToml do
+    it "offers sensible defaults" do
+      stellar_toml = described_class.new
+
+      expect(stellar_toml.TRANSFER_SERVER)
+        .to eq StellarBase::Engine.routes.url_helpers.withdraw_url
+    end
+  end
+end

--- a/spec/requests/well_known_spec.rb
+++ b/spec/requests/well_known_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe "GET /.well-known/stellar", type: :request do
+  it "exposes the stellar.toml" do
+    get "/.well-known/stellar"
+
+    expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
+
+    toml_hash = TomlRB.parse(response.body)
+
+    expect(toml_hash["TRANSFER_SERVER"])
+      .to eq "http://example.com/.well-known/stellar"
+  end
+end

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -2,10 +2,9 @@ CONFIG = YAML.load_file(SPEC_DIR.join("config.yml")).with_indifferent_access
 CONFIG[:issuer_address] = Stellar::Account.random.address
 
 RSpec.configure do |c|
-
   c.before(:each) do
     StellarBase.configure do |c|
-      c.modules = %i(bridge_callbacks withdraw)
+      c.modules = %i[bridge_callbacks withdraw]
       c.horizon_url = "https://horizon-testnet.stellar.org"
 
       c.distribution_account = "G-DISTRO-ACCOUNT"
@@ -22,10 +21,12 @@ RSpec.configure do |c|
           asset_code: "BTCT",
           issuer: CONFIG[:issuer_address],
           fee_fixed: 0.01,
-        }
+        },
       ]
       c.on_withdraw = ProcessWithdrawal.to_s
+      c.stellar_toml = {
+        TRANSFER_SERVER: "http://example.com/.well-known/stellar",
+      }
     end
   end
-
 end


### PR DESCRIPTION
Add capability for users to use a `mount_stellar_base_well_known` route helper in `config/routes.rb`. To configure the content you can configure a hash in the config file:

```
StellarBase.configuration do |c|
  c.stellar_toml = {}
end
```

### c.stellar_toml
- Value(s): Hash, follow Stellar's [documentation](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) for `stellar.toml`
- Example:
```
c.stellar_toml = {
  TRANSFER_SERVER: ...,
  FEDERATION_SERVER: ...,
  AUTH_SERVER: ...,
}
```