### PR TITLE
`BridgeCallbacks::Operations::Create` should check the correct module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- BridgeCallbacks operation should check if `bridge_callbacks` is included.
+
 ## [0.5.0]
 ### Added
 - Add capability for mounting `/.well-known` using a route helper: `mount_stellar_base_well_known`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stellar_base-rails (0.5.0)
+    stellar_base-rails (0.5.1)
       disposable
       dry-types
       gem_config

--- a/app/concepts/stellar_base/bridge_callbacks/bridge_callback_policy.rb
+++ b/app/concepts/stellar_base/bridge_callbacks/bridge_callback_policy.rb
@@ -6,7 +6,7 @@ module StellarBase
       end
 
       def create?
-        StellarBase.included_module?(:withdraw)
+        StellarBase.included_module?(:bridge_callbacks)
       end
 
     end

--- a/lib/stellar_base/version.rb
+++ b/lib/stellar_base/version.rb
@@ -1,3 +1,3 @@
 module StellarBase
-  VERSION = "0.5.0".freeze
+  VERSION = "0.5.1".freeze
 end


### PR DESCRIPTION
## Description
The operation should check if `bridge_callbacks` is included, not `withdraw`