### PR TITLE
Configurable max_amount populator 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Add `max_amount_from` configuration for `c.withdrawable_assets` to properly populate `WithdrawalRequest#max_amount`
+
 ## [0.5.5]
 ### Added
 - Add errors in `/withdraw` to include errors for invalid asset codes instead of silently failing

--- a/app/concepts/stellar_base/withdrawal_requests/contracts/create.rb
+++ b/app/concepts/stellar_base/withdrawal_requests/contracts/create.rb
@@ -19,9 +19,7 @@ module StellarBase
         validate :check_valid_asset_code
 
         def check_valid_asset_code
-          asset_codes = StellarBase
-            .configuration
-            .withdrawable_assets
+          asset_codes = StellarBase.configuration.withdrawable_assets
             &.map do |asset|
               asset[:asset_code]
             end

--- a/app/services/stellar_base/withdrawal_requests/determine_max_amount.rb
+++ b/app/services/stellar_base/withdrawal_requests/determine_max_amount.rb
@@ -1,0 +1,14 @@
+module StellarBase
+  module WithdrawalRequests
+    class DetermineMaxAmount
+
+      DEFAULT = nil
+
+      def self.call(class_name)
+        return class_name.constantize.send(:call) if class_name.present?
+        DEFAULT
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/withdrawal_requests/find_withdrawable_asset.rb
+++ b/app/services/stellar_base/withdrawal_requests/find_withdrawable_asset.rb
@@ -1,0 +1,12 @@
+module StellarBase
+  module WithdrawalRequests
+    class FindWithdrawableAsset
+
+      def self.call(asset_code)
+        withdrawable_assets = StellarBase.configuration.withdrawable_assets
+        withdrawable_assets.find {|asset| asset[:asset_code] == asset_code }
+      end
+
+    end
+  end
+end

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,13 +1,13 @@
 # Modules
 
-# Bridge Callbacks
+## Bridge Callbacks
 
 Activate this by specifying `bridge_callbacks` in the `modules` configuration.
 
 This will mount the `/bridge_callbacks` endpoint. Make sure you setup `on_bridge_callback` like below.
 
-## c.on_bridge_callback
-- Value(s): 
+#### c.on_bridge_callback
+- Value(s):
   - object that responds to `.call` accepts the argument:
     - `bridge_callback`
   - String version of the object
@@ -33,22 +33,22 @@ class ProcessBridgeCallback
 end
 ```
 
-## c.check_bridge_callbacks_authenticity
+#### c.check_bridge_callbacks_authenticity
 - Value(s): `true` or `false`
 - Default: `false`
 - This secures the `/bridge_callbacks` endpoint from fake transactions by checking the transaction ID and it's contents against the Stellar Blockchain. If it doesn't add up, `/bridge_callbacks` endpoint will respond with a 422
 
-## c.check_bridge_callbacks_mac_payload
+#### c.check_bridge_callbacks_mac_payload
 - Value(s): `true` or `false`
 - Default: `false`
 - This secures the `/bridge_callbacks` endpoint from fake transactions by checking the `X_PAYLOAD_MAC` header for 1.) existence and 2.) if it matches the HMAC-SH256 encoded raw request body
 
-## c.bridge_callbacks_mac_key
+####  c.bridge_callbacks_mac_key
 - Value(s): Any Stellar Private Key, it should be the same as the mac_key configured in your bridge server
 - Default: None
 - This is used to verify the contents of `X_PAYLOAD_MAC` by encoding the raw request body with the decoded `bridge_callback_mac_key` as the key
 
-# [Withdraw](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#withdraw)
+## [Withdraw](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#withdraw)
 
 Activate this by specifying `withdraw` in the `modules` configuration.
 
@@ -72,20 +72,25 @@ end
 
 You can also just pass in `StellarBase::WithdrawalRequests::Process` directly into `on_bridge_callback` if you don't need to do anything else.
 
-## c.withdrawable_assets
+#### c.withdrawable_assets
 - Value(s):
   - path to a YAML configuration file describing what can be withdrawn (see below), or
   - JSON: array of JSON objects following the YAML but in JSON format, or
   - Ruby array of hashes
+  - Sample [withdrawal.yml](docs/withdraw.yml)
 - Required
+- Notes: `max_amount_from` is a class that you define that will run whenever a withdrawal for that asset is requested. It'll populate the `max_amount` response field. If you don't define anything, it won't run that class and will return `nil`
+  - The `max_amount_from` class is expected a `BigDecimal` return.
+  - The `max_amount_from` class is expected to implement a `self.call` method. It won't be passed any parameters
 
-## c.on_withdraw
+#### c.on_withdraw
 - Value(s):
   - object that responds to `.call` accepts the arguments:
     - `withdrawal_request`
     - `bridge_callback`
   - String version of the object
 - Required
+- Notes: This is run when a `GET /withdraw` is received and has passed validations
 
 Example:
 

--- a/docs/withdraw.yml
+++ b/docs/withdraw.yml
@@ -5,8 +5,10 @@
   issuer: G-issuer-on-stellar
   fee_fixed: 0.01
   fee_percent: 10.0
+  max_amount_from: "Withdraw:Bitcoin::GetBalance"
 - type: crypto
   network: ethereum
   asset_code: ETH
   issuer: G-issuer-on-stellar
+  max_amount_from: "Withdraw:Ethereum::GetBalance"
   # if no fee is specified, it is 0

--- a/spec/concepts/stellar_base/withdrawal_requests/operations/create_spec.rb
+++ b/spec/concepts/stellar_base/withdrawal_requests/operations/create_spec.rb
@@ -4,14 +4,14 @@ module StellarBase
   module WithdrawalRequests
     module Operations
       RSpec.describe Create do
-
         it "creates a withdrawal request" do
           expect(GenMemo).to receive(:call).and_return("MEMO")
+          expect(DetermineMaxAmount).to receive(:call).and_return(10)
           expect(DetermineFee).to receive(:call).with(0.01).and_return(0.01)
-          expect(DetermineFee).to receive(:call).with(nil).
-            and_return(0.0)
-          expect(DetermineFee).to receive(:network).with("bitcoin", 0.0005).
-            and_return(0.0005)
+          expect(DetermineFee).to receive(:call).with(nil)
+            .and_return(0.0)
+          expect(DetermineFee).to receive(:network).with("bitcoin", 0.0005)
+            .and_return(0.0005)
 
           op = described_class.(withdrawal_request: {
             type: "crypto",
@@ -28,13 +28,13 @@ module StellarBase
           expect(withdrawal_request.dest).to eq "my-btc-addr"
           expect(withdrawal_request.dest_extra).to eq "pls"
           expect(withdrawal_request.issuer).to eq CONFIG[:issuer_address]
-          expect(withdrawal_request.account_id).
-            to eq StellarBase.configuration.distribution_account
+          expect(withdrawal_request.account_id)
+            .to eq StellarBase.configuration.distribution_account
           expect(withdrawal_request.memo_type).to eq "text"
           expect(withdrawal_request.memo).to be_present
           expect(withdrawal_request.eta).to be_an Integer
           expect(withdrawal_request.min_amount).to be_a BigDecimal
-          expect(withdrawal_request.max_amount).to be_nil
+          expect(withdrawal_request.max_amount).to eq 10
           expect(withdrawal_request.fee_fixed).to eq 0.01
           expect(withdrawal_request.fee_percent).to be_zero
           expect(withdrawal_request.fee_network).to eq 0.0005
@@ -59,7 +59,7 @@ module StellarBase
 
         context "bridge_callbacks module is not loaded" do
           before do
-            StellarBase.configuration.modules = %i()
+            StellarBase.configuration.modules = %i[]
           end
 
           it "creates a withdrawal request" do
@@ -74,7 +74,6 @@ module StellarBase
             expect(op).to_not be_success
           end
         end
-
       end
     end
   end

--- a/spec/dummy/app/services/get_max_amount.rb
+++ b/spec/dummy/app/services/get_max_amount.rb
@@ -1,5 +1,7 @@
 class GetMaxAmount
 
-  def self.call; end
+  def self.call
+    1
+  end
 
 end

--- a/spec/dummy/app/services/get_max_amount.rb
+++ b/spec/dummy/app/services/get_max_amount.rb
@@ -1,0 +1,5 @@
+class GetMaxAmount
+
+  def self.call; end
+
+end

--- a/spec/services/stellar_base/withdrawal_requests/determine_max_amount_spec.rb
+++ b/spec/services/stellar_base/withdrawal_requests/determine_max_amount_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+module StellarBase
+  module WithdrawalRequests
+    RSpec.describe DetermineMaxAmount do
+      context "given a class name" do
+        it "runs that class" do
+          expect(GetMaxAmount).to receive(:call).and_return(1)
+          described_class.(GetMaxAmount.to_s)
+        end
+      end
+
+      context "given no class name" do
+        it "returns nil" do
+          expect(described_class.("")).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/withdrawal_requests/find_withdrawable_asset_spec.rb
+++ b/spec/services/stellar_base/withdrawal_requests/find_withdrawable_asset_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+module StellarBase
+  module WithdrawalRequests
+    RSpec.describe FindWithdrawableAsset do
+      it "returns hash of a withdrawable_asset" do
+        details = described_class.("BTCT")
+        expect(details[:type]).to eq "crypto"
+        expect(details[:asset_code]).to eq "BTCT"
+        expect(details[:fee_fixed]).to eq 0.01
+      end
+    end
+  end
+end

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -21,6 +21,7 @@ RSpec.configure do |c|
           asset_code: "BTCT",
           issuer: CONFIG[:issuer_address],
           fee_fixed: 0.01,
+          max_amount_from: GetMaxAmount.to_s,
         },
       ]
       c.on_withdraw = ProcessWithdrawal.to_s


### PR DESCRIPTION
This PR contains commits for a feature that allows `stellar_base-rails` users to provide a service class that populates the `GET /withdraw #max_amount` field.