### PR TITLE
Return error message if withdraw policy is denied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Missing local variable `address` when `StellarBase::AccountSubscriptions::GetOperations` rescues `Faraday::ClientError` exception
+- Add error message in `/withdraw` if a failed policy occurred.
 
 ## [0.9.4] - 2018-10-08
 ### Fixed

--- a/app/concepts/stellar_base/withdrawal_requests/operations/create.rb
+++ b/app/concepts/stellar_base/withdrawal_requests/operations/create.rb
@@ -4,8 +4,10 @@ module StellarBase
       class Create < ApplicationOperation
 
         DEFAULT_ETA = (10 * 60).freeze
+        POLICY_ERROR_MESSAGE = "You are unauthorized to request withdrawal details"
 
         step self::Policy::Pundit(WithdrawalRequestPolicy, :create?)
+        failure :set_policy_error!
         step Model(WithdrawalRequest, :new)
         step :setup_params!
         step Contract::Build(constant: Contracts::Create)
@@ -16,6 +18,10 @@ module StellarBase
         step Contract::Persist(method: :save)
 
         private
+
+        def set_policy_error!(options, params:, **)
+          options["result.policy.message"] = POLICY_ERROR_MESSAGE
+        end
 
         def setup_params!(options, params:, **)
           params[:withdrawal_request].merge!({

--- a/app/controllers/stellar_base/withdraw_controller.rb
+++ b/app/controllers/stellar_base/withdraw_controller.rb
@@ -13,7 +13,7 @@ module StellarBase
             render json: representer
           else
             render(
-              json: { error: op["contract.default"].errors },
+              json: { error: op["result.policy.message"] || op["contract.default"].errors },
               status: :unprocessable_entity,
             )
           end

--- a/spec/requests/withdraw_spec.rb
+++ b/spec/requests/withdraw_spec.rb
@@ -98,4 +98,27 @@ describe "GET /withdraw", type: :request, vcr: { record: :once } do
       expect(@callback_called).to be_nil
     end
   end
+
+  context "requesting withdrawal details without the `withdraw` module" do
+    before do
+      StellarBase.configuration.modules = %w[bridge_callbacks]
+    end
+
+    it "denies access" do
+      get(uri, {
+        params: {
+          type: "crypto",
+          asset_code: "BTCT",
+          dest: "my-btc-address",
+          fee_network: 0.001,
+          format: :json,
+        },
+      })
+
+      json = JSON.parse(response.body).with_indifferent_access
+
+      expect(response).to_not be_success
+      expect(json["error"]).to_not be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Problem
For rare cases where a `withdraw` module is not configured, access to `/withdraw` endpoint will be denied by the policy. If this happens, the endpoint wont be able to handle it thus the call will fail (404).

## Solution
It should respond with a clear error message on why the call failed. In this case, a policy error.