### PR TITLE
Users can trigger sending of asset when a deposit is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Add `StellarBase.on_deposit_trigger`
+- Add `StellarBase.configuration.stellar_network`
+
 ## [0.6.1]
 ### Changed
 - Use 0 if `max_amount_from` in `DepositRequests::Operations::Create`

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,7 @@ gemspec
 gem "pry-byebug", group: %i[development test]
 gem "spring"
 gem "spring-commands-rspec"
+gem("stellar-sdk", {
+  github: "bloom-solutions/ruby-stellar-sdk",
+  branch: "payment-memo",
+})

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: git://github.com/bloom-solutions/ruby-stellar-sdk.git
+  revision: dcf6ef2ac9f491e232352c0388cfba8990dafc0b
+  branch: payment-memo
+  specs:
+    stellar-sdk (0.5.0)
+      activesupport (>= 5.2.0)
+      contracts (~> 0.16)
+      excon (~> 0.44, >= 0.44.4)
+      hyperclient (~> 0.7)
+      stellar-base (>= 0.16.0)
+      toml-rb (~> 1.1, >= 1.1.1)
+
 PATH
   remote: .
   specs:
@@ -121,7 +134,7 @@ GEM
     factory_bot_rails (4.10.0)
       factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
-    faraday (0.15.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     faraday-digestauth (0.3.0)
       faraday (~> 0.7)
@@ -255,13 +268,6 @@ GEM
       rbnacl
       rbnacl-libsodium (~> 1.0.16)
       xdr (~> 3.0.0)
-    stellar-sdk (0.5.0)
-      activesupport (>= 5.2.0)
-      contracts (~> 0.16)
-      excon (~> 0.44, >= 0.44.4)
-      hyperclient (~> 0.7)
-      stellar-base (>= 0.16.0)
-      toml-rb (~> 1.1, >= 1.1.1)
     thor (0.20.0)
     thread_safe (0.3.6)
     toml-rb (1.1.2)
@@ -310,7 +316,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sqlite3
-  stellar-sdk
+  stellar-sdk!
   stellar_base-rails!
   vcr (~> 4.0)
   webmock

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ And then execute:
 $ bundle
 ```
 
+If you're using `StellarBase.on_deposit_trigger` you'll need to install:
+
+```
+# Gemfile
+gem("stellar-sdk", {
+  github: "bloom-solutions/ruby-stellar-sdk",
+  branch: "payment-memo",
+})
+```
+
 ## Development
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ This is the same distribution account that is setup in bridge. Currently, it is 
 - Default: https://horizon.stellar.org
 - This is where the engine will check bridge callbacks if `c.check_bridge_callbacks_authenticity` is turned on
 
+#### c.stellar_network
+- Values(s): "public" or "testnet"
+- Default: testnet
+- This tells stellar_base-rails what network it will use to send assets/lumens with. Currently used by the deposit module. If someone deposits a real asset, stellar_base sends the corresponding token to the requester.
+
 #### c.stellar_toml
 - Value(s): Hash, follow Stellar's [documentation](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) for `stellar.toml`
 - Example:

--- a/app/models/stellar_base/deposit.rb
+++ b/app/models/stellar_base/deposit.rb
@@ -1,0 +1,7 @@
+module StellarBase
+  class Deposit < ApplicationRecord
+
+    belongs_to :deposit_request, class_name: "StellarBase::DepositRequest"
+
+  end
+end

--- a/app/services/stellar_base/deposit_requests/create_deposit.rb
+++ b/app/services/stellar_base/deposit_requests/create_deposit.rb
@@ -1,0 +1,19 @@
+module StellarBase
+  module DepositRequests
+    class CreateDeposit
+
+      extend LightService::Action
+      expects :tx_id, :amount, :deposit_request
+      promises :deposit
+
+      executed do |c|
+        c.deposit = Deposit.create!(
+          tx_id: c.tx_id,
+          amount: c.amount,
+          deposit_request_id: c.deposit_request.id,
+        )
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/find_config.rb
+++ b/app/services/stellar_base/deposit_requests/find_config.rb
@@ -8,7 +8,7 @@ module StellarBase
       promises :deposit_config
 
       executed do |c|
-        depositable_assets = StellarBase.configuration.depositable_assets.dup
+        depositable_assets = StellarBase.configuration.depositable_assets
         c.deposit_config = depositable_assets.find do |asset|
           asset[:network] == c.network
         end

--- a/app/services/stellar_base/deposit_requests/find_config.rb
+++ b/app/services/stellar_base/deposit_requests/find_config.rb
@@ -1,0 +1,23 @@
+module StellarBase
+  module DepositRequests
+    class FindConfig
+
+      extend LightService::Action
+
+      expects :network
+      promises :deposit_config
+
+      executed do |c|
+        depositable_assets = StellarBase.configuration.depositable_assets.dup
+        c.deposit_config = depositable_assets.find do |asset|
+          asset[:network] == c.network
+        end
+
+        if c.deposit_config.blank?
+          c.fail_and_return! "No depositable_asset config for #{c.network}"
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/find_deposit.rb
+++ b/app/services/stellar_base/deposit_requests/find_deposit.rb
@@ -1,0 +1,21 @@
+module StellarBase
+  module DepositRequests
+    class FindDeposit
+
+      extend LightService::Action
+
+      expects :deposit_request, :tx_id
+      promises :deposit
+
+      executed do |c|
+        c.deposit = Deposit.find_by(
+          deposit_request_id: c.deposit_request.id,
+          tx_id: c.tx_id,
+        )
+
+        c.skip_remaining! if c.deposit.present?
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/find_deposit_request.rb
+++ b/app/services/stellar_base/deposit_requests/find_deposit_request.rb
@@ -1,0 +1,27 @@
+module StellarBase
+  module DepositRequests
+    class FindDepositRequest
+
+      extend LightService::Action
+
+      expects :deposit_config, :deposit_address
+      promises :deposit_request
+
+      executed do |c|
+        deposit_address = c.deposit_address
+        asset_code = c.deposit_config[:asset_code]
+
+        c.deposit_request = DepositRequest.find_by(
+          deposit_address: deposit_address,
+          asset_code: asset_code,
+        )
+
+        if c.deposit_request.blank?
+          c.fail_and_return! "No DepositRequest found for " +
+            [asset_code, deposit_address].join(":")
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/init_stellar_amount.rb
+++ b/app/services/stellar_base/deposit_requests/init_stellar_amount.rb
@@ -1,0 +1,15 @@
+module StellarBase
+  module DepositRequests
+    class InitStellarAmount
+
+      extend LightService::Action
+      expects :stellar_asset, :amount
+      promises :stellar_amount
+
+      executed do |c|
+        c.stellar_amount = Stellar::Amount.new(c.amount, c.stellar_asset)
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/init_stellar_asset.rb
+++ b/app/services/stellar_base/deposit_requests/init_stellar_asset.rb
@@ -1,0 +1,18 @@
+module StellarBase
+  module DepositRequests
+    class InitStellarAsset
+
+      extend LightService::Action
+      expects :deposit_request, :issuer_account
+      promises :stellar_asset
+
+      executed do |c|
+        c.stellar_asset = Stellar::Asset.alphanum4(
+          c.deposit_request.asset_code,
+          c.issuer_account.keypair,
+        )
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/init_stellar_distribution_account.rb
+++ b/app/services/stellar_base/deposit_requests/init_stellar_distribution_account.rb
@@ -1,0 +1,17 @@
+module StellarBase
+  module DepositRequests
+    class InitStellarDistributionAccount
+
+      extend LightService::Action
+      expects :deposit_config
+      promises :distribution_account
+
+      executed do |c|
+        config = c.deposit_config
+        c.distribution_account = Stellar::Account
+          .from_seed(config[:distributor_seed])
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/init_stellar_issuer_account.rb
+++ b/app/services/stellar_base/deposit_requests/init_stellar_issuer_account.rb
@@ -1,0 +1,16 @@
+module StellarBase
+  module DepositRequests
+    class InitStellarIssuerAccount
+
+      extend LightService::Action
+      expects :deposit_config
+      promises :issuer_account
+
+      executed do |c|
+        config = c.deposit_config
+        c.issuer_account = Stellar::Account.from_address(config[:issuer])
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/init_stellar_recipient_account.rb
+++ b/app/services/stellar_base/deposit_requests/init_stellar_recipient_account.rb
@@ -1,0 +1,16 @@
+module StellarBase
+  module DepositRequests
+    class InitStellarRecipientAccount
+
+      extend LightService::Action
+      expects :deposit_request
+      promises :recipient_account
+
+      executed do |c|
+        c.recipient_account = Stellar::Account
+          .from_address(c.deposit_request.account_id)
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/send_asset.rb
+++ b/app/services/stellar_base/deposit_requests/send_asset.rb
@@ -1,0 +1,40 @@
+module StellarBase
+  module DepositRequests
+    class SendAsset
+
+      extend LightService::Action
+      expects(
+        :deposit_request,
+        :distribution_account,
+        :issuer_account,
+        :recipient_account,
+        :stellar_amount,
+        :stellar_sdk_client,
+      )
+      promises :stellar_tx_id
+
+      executed do |c|
+        msg = [
+          "issuing account: #{c.issuer_account.address}",
+          "recipient account: #{c.recipient_account.address}",
+          "stellar amount: #{c.stellar_amount.amount}#{c.stellar_amount.asset}",
+          "distribution account: #{c.distribution_account.address}",
+          "recipient memo: #{c.deposit_request.memo}",
+        ].join("; ")
+
+        Rails.logger.info(msg)
+
+        # TODO: handle when this fails
+        response = c.stellar_sdk_client.send_payment(
+          from: c.distribution_account,
+          to: c.recipient_account,
+          amount: c.stellar_amount,
+          memo: c.deposit_request.memo,
+        )
+
+        c.stellar_tx_id = response.to_hash["hash"]
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/trigger.rb
+++ b/app/services/stellar_base/deposit_requests/trigger.rb
@@ -1,0 +1,35 @@
+module StellarBase
+  module DepositRequests
+    class Trigger
+
+      extend LightService::Organizer
+
+      def self.call(network, deposit_address, tx_id, amount)
+        with(
+          network: network,
+          deposit_address: deposit_address,
+          tx_id: tx_id,
+          amount: amount,
+        ).reduce(actions)
+      end
+
+      def self.actions
+        [
+          FindConfig,
+          FindDepositRequest,
+          FindDeposit,
+          CreateDeposit,
+          InitStellarClient,
+          InitStellarIssuerAccount,
+          InitStellarRecipientAccount,
+          InitStellarDistributionAccount,
+          InitStellarAsset,
+          InitStellarAmount,
+          SendAsset,
+          UpdateDeposit, # save the stellar operation id on it
+        ]
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/update_deposit.rb
+++ b/app/services/stellar_base/deposit_requests/update_deposit.rb
@@ -1,0 +1,14 @@
+module StellarBase
+  module DepositRequests
+    class UpdateDeposit
+
+      extend LightService::Action
+      expects :stellar_tx_id, :deposit
+
+      executed do |c|
+        c.deposit.update!(stellar_tx_id: c.stellar_tx_id)
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/init_stellar_client.rb
+++ b/app/services/stellar_base/init_stellar_client.rb
@@ -1,0 +1,14 @@
+module StellarBase
+  class InitStellarClient
+
+    extend LightService::Action
+    promises :stellar_sdk_client
+
+    executed do |c|
+      c.stellar_sdk_client = Stellar::Client.new(
+        horizon: StellarBase.configuration.horizon_url,
+      )
+    end
+
+  end
+end

--- a/db/migrate/20181001070647_create_stellar_base_deposits.rb
+++ b/db/migrate/20181001070647_create_stellar_base_deposits.rb
@@ -1,0 +1,18 @@
+class CreateStellarBaseDeposits < ActiveRecord::Migration[5.2]
+
+  def change
+    create_table :stellar_base_deposits do |t|
+      t.integer :deposit_request_id, index: true
+      t.string :tx_id, index: true
+      t.decimal :amount
+      t.string :stellar_operation_id
+
+      t.timestamps
+    end
+
+    add_foreign_key(:stellar_base_deposits, :stellar_base_deposit_requests, {
+      column: :deposit_request_id,
+    })
+  end
+
+end

--- a/db/migrate/20181001070647_create_stellar_base_deposits.rb
+++ b/db/migrate/20181001070647_create_stellar_base_deposits.rb
@@ -5,7 +5,7 @@ class CreateStellarBaseDeposits < ActiveRecord::Migration[5.2]
       t.integer :deposit_request_id, index: true
       t.string :tx_id, index: true
       t.decimal :amount
-      t.string :stellar_operation_id
+      t.string :stellar_tx_id
 
       t.timestamps
     end

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -118,9 +118,9 @@ Activate this by specifying `deposit` in the `modules` configuration.
 
 This will mount the `/deposit` endpoint.
 
-#### `StellarBase::Deposits::Trigger`
+#### `StellarBase.on_deposit_trigger`
 
-This engine gives you a class called `StellarBase::Deposits::Trigger` you call this in your application once you've received the asset in your system. This will send the appropriate token to the Stellar Account of the requester.
+This engine gives you a method called `StellarBase.on_deposit_trigger` you call this in your application once you've received the asset in your system. This will send the appropriate token to the Stellar Account of the requester.
 
 - Parameters:
   - network, deposit_address, tx_id, amount

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -17,51 +17,67 @@ module StellarBase
   include GemConfig::Base
 
   with_configuration do
-    has :horizon_url, default: "https://horizon.stellar.org"
-    has :modules, default: [:bridge_callbacks]
-
-    has :distribution_account, classes: [NilClass, String]
-
-    has :on_bridge_callback
+    has :bridge_callbacks_mac_key, default: false
     has :check_bridge_callbacks_authenticity, default: false
     has :check_bridge_callbacks_mac_payload, default: false
-    has :bridge_callbacks_mac_key, default: false
-
-    has :withdrawable_assets, classes: [NilClass, Array, String, Pathname]
+    has :distribution_account, classes: [NilClass, String]
+    has :horizon_url, default: "https://horizon.stellar.org"
+    has :modules, default: [:bridge_callbacks]
+    has :on_bridge_callback
     has :on_withdraw
-
-    has :depositable_assets, classes: [NilClass, Array, String, Pathname]
-
+    has :stellar_network, classes: String, default: "testnet"
     has :stellar_toml, classes: Hash, default: {}
+    has :depositable_assets, classes: [NilClass, Array, String, Pathname]
+    has :withdrawable_assets, classes: [NilClass, Array, String, Pathname]
   end
 
   after_configuration_change do
-    self.convert_config_withdraw!
-    self.convert_config_deposit!
+    convert_config_withdraw!
+    convert_config_deposit!
+    set_stellar_network!
   end
 
+  def self.on_deposit_trigger(network:, deposit_address:, tx_id:, amount:)
+    result = DepositRequests::Trigger.(network, deposit_address, tx_id, amount)
+    raise StandardError, result.message if result.failure?
+    result
+  end
 
   def self.included_module?(module_name)
-    self.configuration.modules&.include?(module_name)
+    configuration.modules&.include?(module_name)
+  end
+
+  def self.set_stellar_network!
+    stellar_network = configuration.stellar_network
+
+    case stellar_network
+    when "public"
+      Stellar.default_network = Stellar::Networks::PUBLIC
+    when "testnet"
+      Stellar.default_network = Stellar::Networks::TESTNET
+    else
+      raise(
+        ArgumentError,
+        "'#{stellar_network}' not a valid stellar_network config",
+      )
+    end
   end
 
   def self.convert_config_deposit!
-    depositable_assets = self.configuration.depositable_assets
+    depositable_assets = configuration.depositable_assets
     return if depositable_assets.is_a?(Array) || depositable_assets.nil?
 
-    self.configuration.depositable_assets =
+    configuration.depositable_assets =
       convert_config!(depositable_assets)
   end
 
   def self.convert_config_withdraw!
-    withdrawable_assets = self.configuration.withdrawable_assets
+    withdrawable_assets = configuration.withdrawable_assets
     return if withdrawable_assets.is_a?(Array) || withdrawable_assets.nil?
 
-    self.configuration.withdrawable_assets =
+    configuration.withdrawable_assets =
       convert_config!(withdrawable_assets)
   end
-
-  private
 
   def self.convert_config!(asset_config)
     array_of_hashes = try_from_yaml_file_path(asset_config) ||
@@ -69,16 +85,19 @@ module StellarBase
 
     array_of_hashes.map(&:with_indifferent_access)
   end
+  private_class_method :convert_config!
 
   def self.try_from_json(str)
     JSON.parse(str)
   rescue JSON::ParserError
   end
+  private_class_method :try_from_json
 
   def self.try_from_yaml_file_path(str)
     YAML.load_file(str.to_s)
   rescue Errno::ENOENT
   end
+  private_class_method :try_from_yaml_file_path
 end
 
 require "stellar_base/horizon_client"

--- a/lib/stellar_base/factories/deposit_requests.rb
+++ b/lib/stellar_base/factories/deposit_requests.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
-
   factory :stellar_base_deposit_request, class: "StellarBase::DepositRequest" do
     deposit_address { "dep-addr" }
+    asset_type { "crypto" }
     issuer { "issuer-addr" }
     memo_type { "text" }
     memo { "ABAC" }
@@ -13,5 +13,4 @@ FactoryBot.define do
     fee_fixed { 0 }
     fee_percent { 0 }
   end
-
 end

--- a/lib/stellar_base/factories/deposit_requests.rb
+++ b/lib/stellar_base/factories/deposit_requests.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :stellar_base_deposit_request, class: "StellarBase::DepositRequest" do
     deposit_address { "dep-addr" }
+    asset_code { "BTCT" }
     asset_type { "crypto" }
     issuer { "issuer-addr" }
     memo_type { "text" }

--- a/lib/stellar_base/factories/deposits.rb
+++ b/lib/stellar_base/factories/deposits.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :stellar_base_deposit, class: "StellarBase::Deposit" do
-    stellar_operation_id { "issuer-addr" }
+    stellar_tx_id { "issuer-addr" }
     deposit_request do
       StellarBase::DepositRequest.first ||
         association(:stellar_base_deposit_request)

--- a/lib/stellar_base/factories/deposits.rb
+++ b/lib/stellar_base/factories/deposits.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :stellar_base_deposit, class: "StellarBase::Deposit" do
+    stellar_operation_id { "issuer-addr" }
+    deposit_request do
+      StellarBase::DepositRequest.first ||
+        association(:stellar_base_deposit_request)
+    end
+    tx_id { "dep-addr" }
+    amount { "crypto" }
+  end
+end

--- a/spec/acceptance/on_deposit_trigger_spec.rb
+++ b/spec/acceptance/on_deposit_trigger_spec.rb
@@ -1,0 +1,140 @@
+require "spec_helper"
+
+describe "StellarBase.on_deposit_trigger" do
+  context "deposit_config not found" do
+    it "skips remaining actions and fails" do
+      expect {
+        StellarBase.on_deposit_trigger(
+          network: "eth",
+          deposit_address: "1bc",
+          tx_id: "",
+          amount: 0.5,
+        )
+      }.to raise_error StandardError, "No depositable_asset config for eth"
+    end
+  end
+
+  context "deposit_request doesn't exist" do
+    it "skips remaining actions" do
+      expect {
+        StellarBase.on_deposit_trigger(
+          network: "bitcoin",
+          deposit_address: "1bc",
+          tx_id: "",
+          amount: 0.5,
+        )
+      }.to raise_error StandardError, "No DepositRequest found for BTCT:1bc"
+    end
+  end
+
+  context "deposit_request exists, but has previous deposit" do
+    let(:deposit_request) do
+      create(:stellar_base_deposit_request, {
+        asset_code: "BTCT",
+        deposit_address: "1bc",
+      })
+    end
+    let!(:deposit) do
+      create(:stellar_base_deposit, {
+        amount: 0.35,
+        deposit_request: deposit_request,
+        stellar_tx_id: "s12",
+        tx_id: "def",
+      })
+    end
+
+    it "skips remaining actions" do
+      result = StellarBase.on_deposit_trigger(
+        network: "bitcoin",
+        deposit_address: "1bc",
+        tx_id: "def",
+        amount: 0.5,
+      )
+
+      expect(result.deposit.amount).to eq 0.35
+      expect(result.deposit.stellar_tx_id).to eq "s12"
+      expect(result.deposit.tx_id).to eq "def"
+    end
+  end
+
+  context(
+    "deposit_request exists, but has no previous deposit",
+    vcr: { record: :once, match_requests_on: [:method] },
+  ) do
+    let!(:deposit_request) do
+      create(:stellar_base_deposit_request, {
+        asset_code: "BTCT",
+        deposit_address: "1bc",
+        account_id: recipient_account.address,
+      })
+    end
+    let(:recipient_account) { Stellar::Account.random }
+    let(:issuing_account) { Stellar::Account.from_seed(CONFIG[:issuer_seed]) }
+    let(:distribution_account) { Stellar::Account.random }
+    let(:client) { Stellar::Client.default_testnet }
+    let(:asset) { Stellar::Asset.alphanum4("BTCT", issuing_account.keypair) }
+
+    before do
+      StellarBase.configuration.depositable_assets = [
+        {
+          type: "crypto",
+          network: "bitcoin",
+          asset_code: "BTCT",
+          issuer: issuing_account.address,
+          distributor: distribution_account.address,
+          distributor_seed: distribution_account.keypair.seed,
+          how_from: GetHow.to_s,
+          max_amount_from: GetMaxAmount.to_s,
+        },
+      ]
+
+      [distribution_account, recipient_account].each do |account|
+        client.create_account(
+          funder: issuing_account,
+          account: account,
+          starting_balance: 2,
+        )
+
+        client.change_trust(
+          asset: [:alphanum4, "BTCT", issuing_account.keypair],
+          source: account,
+        )
+      end
+
+      amount = Stellar::Amount.new(3, asset)
+
+      client.send_payment(
+        from: issuing_account,
+        to: distribution_account,
+        amount: amount,
+      )
+    end
+
+    it "creates the deposit and sends the stellar asset" do
+      result = StellarBase.on_deposit_trigger(
+        network: "bitcoin",
+        deposit_address: "1bc",
+        tx_id: "2cd",
+        amount: 0.05,
+      )
+
+      expect(result).to be_success
+
+      deposit = result.deposit
+
+      expect(deposit).to be_present
+      expect(deposit).to be_persisted
+      expect(deposit.tx_id).to eq "2cd"
+      expect(deposit.amount).to eq 0.05
+      expect(deposit.stellar_tx_id).to be_present
+
+      response = client.account_info(recipient_account)
+
+      btct_balance = response.balances.find do |balance|
+        balance["asset_code"] == "BTCT"
+      end
+
+      expect(btct_balance["balance"].to_f).to eq 0.05
+    end
+  end
+end

--- a/spec/config.yml.sample
+++ b/spec/config.yml.sample
@@ -1,5 +1,4 @@
 ---
 source_seed: change me to a seed with lumens on the testnet
 source_address: change mt to the address of the seed above
-issuer_seed: this is the issuer of assets that tests will run against. Make sure it's funded on the testnet
 issuer_address: this is the isser public address

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2018_10_01_070647) do
     t.integer "deposit_request_id"
     t.string "tx_id"
     t.decimal "amount"
-    t.string "stellar_operation_id"
+    t.string "stellar_tx_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["deposit_request_id"], name: "index_stellar_base_deposits_on_deposit_request_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_25_045927) do
+ActiveRecord::Schema.define(version: 2018_10_01_070647) do
 
   create_table "stellar_base_bridge_callbacks", force: :cascade do |t|
     t.string "operation_id", null: false
@@ -50,6 +50,17 @@ ActiveRecord::Schema.define(version: 2018_09_25_045927) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["asset_type", "asset_code"], name: "index_stellar_base_deposit_requests_on_asset"
+  end
+
+  create_table "stellar_base_deposits", force: :cascade do |t|
+    t.integer "deposit_request_id"
+    t.string "tx_id"
+    t.decimal "amount"
+    t.string "stellar_operation_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deposit_request_id"], name: "index_stellar_base_deposits_on_deposit_request_id"
+    t.index ["tx_id"], name: "index_stellar_base_deposits_on_tx_id"
   end
 
   create_table "stellar_base_withdrawal_requests", force: :cascade do |t|

--- a/spec/fixtures/vcr_cassettes/StellarBase_on_deposit_trigger/deposit_request_exists_but_has_no_previous_deposit/creates_the_deposit_and_sends_the_stellar_asset.yml
+++ b/spec/fixtures/vcr_cassettes/StellarBase_on_deposit_trigger/deposit_request_exists_but_has_no_previous_deposit/creates_the_deposit_and_sends_the_stellar_asset.yml
@@ -1,0 +1,2211 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:22 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17174'
+      X-Ratelimit-Reset:
+      - '1698'
+      Content-Length:
+      - '1574'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "0.14.2-4c30d59b86f551475a3ac60e5555c0c86ff3cb75",
+          "core_version": "stellar-core 10.0.0 (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
+          "history_latest_ledger": 11351586,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 11351586,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 10
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:22 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:23 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17184'
+      X-Ratelimit-Reset:
+      - '1604'
+      Content-Length:
+      - '2348'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "paging_token": "",
+          "account_id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "sequence": "46654163857178644",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "9987.9998000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "weight": 1,
+              "key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:23 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:29 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17182'
+      X-Ratelimit-Reset:
+      - '1597'
+      Content-Length:
+      - '2345'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC",
+          "paging_token": "",
+          "account_id": "GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC",
+          "sequence": "48754699217666048",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "2.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC",
+              "weight": 1,
+              "key": "GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:29 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:34 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17180'
+      X-Ratelimit-Reset:
+      - '1592'
+      Content-Length:
+      - '2348'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "paging_token": "",
+          "account_id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "sequence": "46654163857178645",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "9985.9997900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "weight": 1,
+              "key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:35 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:39 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17173'
+      X-Ratelimit-Reset:
+      - '1681'
+      Content-Length:
+      - '2345'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH",
+          "paging_token": "",
+          "account_id": "GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH",
+          "sequence": "48754707807600640",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "2.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH",
+              "weight": 1,
+              "key": "GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:39 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:45 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17171'
+      X-Ratelimit-Reset:
+      - '1675'
+      Content-Length:
+      - '2348'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "paging_token": "",
+          "account_id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "sequence": "46654163857178646",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "9983.9997800",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "weight": 1,
+              "key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:45 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:50 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17169'
+      X-Ratelimit-Reset:
+      - '1670'
+      Content-Length:
+      - '1574'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "0.14.2-4c30d59b86f551475a3ac60e5555c0c86ff3cb75",
+          "core_version": "stellar-core 10.0.0 (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
+          "history_latest_ledger": 11351592,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 11351592,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 10
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:50 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:51 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17178'
+      X-Ratelimit-Reset:
+      - '1575'
+      Content-Length:
+      - '2659'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC",
+          "paging_token": "",
+          "account_id": "GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC",
+          "sequence": "48754699217666049",
+          "subentry_count": 1,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "3.0000000",
+              "limit": "922337203685.4775807",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTCT",
+              "asset_issuer": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            {
+              "balance": "1.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC",
+              "weight": 1,
+              "key": "GCNFMDHXD252UPONDOIJEPLAFOUBI46ADSACTHQJMPFTR3ZUDLOFTWRC",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:52 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:08:55 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17167'
+      X-Ratelimit-Reset:
+      - '1665'
+      Content-Length:
+      - '2659'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH",
+          "paging_token": "",
+          "account_id": "GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH",
+          "sequence": "48754707807600641",
+          "subentry_count": 1,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "0.0500000",
+              "limit": "922337203685.4775807",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTCT",
+              "asset_issuer": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            {
+              "balance": "1.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH",
+              "weight": 1,
+              "key": "GBKF3OLZSAJV5UIKZYAXIUWSVMDJXRORHMJJD4LYRJLQM5GLHIADBJVH",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:08:55 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:24 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17166'
+      X-Ratelimit-Reset:
+      - '1096'
+      Content-Length:
+      - '1574'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "0.14.2-4c30d59b86f551475a3ac60e5555c0c86ff3cb75",
+          "core_version": "stellar-core 10.0.0 (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
+          "history_latest_ledger": 11351706,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 11351706,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 10
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:24 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:25 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17177'
+      X-Ratelimit-Reset:
+      - '1002'
+      Content-Length:
+      - '2348'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "paging_token": "",
+          "account_id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "sequence": "46654163857178647",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "9983.9997700",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "weight": 1,
+              "key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:25 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAOXkO9iJqIHCQtK%2FxOInblvWhvAdV9jOFzuSngD8fAC4AAAAZAClv7cAAAAYAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAfbx78MNkLGq8OMqtB3%2FkTenRSCsndIIB6qywTI66u18AAAAAATEtAAAAAAAAAAAB%2FHwAuAAAAEA8SZ%2BANniIk9BEa7UsV%2FQWdoF4CwnDT%2BwxizstwwVFuYahbd1r%2B4lAqWwvYtYuBDSsZJneeOJS1TK3aGj5h%2FYF
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:30 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17176'
+      X-Ratelimit-Reset:
+      - '1000'
+      Content-Length:
+      - '1309'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/e3f53e9b9986be5c790b4fbaaec91d3069e3fc4ea0c1d895699c1b591325278f"
+            }
+          },
+          "hash": "e3f53e9b9986be5c790b4fbaaec91d3069e3fc4ea0c1d895699c1b591325278f",
+          "ledger": 11351708,
+          "envelope_xdr": "AAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAZAClv7cAAAAYAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAfbx78MNkLGq8OMqtB3/kTenRSCsndIIB6qywTI66u18AAAAAATEtAAAAAAAAAAAB/HwAuAAAAEA8SZ+ANniIk9BEa7UsV/QWdoF4CwnDT+wxizstwwVFuYahbd1r+4lAqWwvYtYuBDSsZJneeOJS1TK3aGj5h/YF",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAK02nAAAAAAAAAAA5eQ72ImogcJC0r/E4iduW9aG8B1X2M4XO5KeAPx8ALgAAAAXPu12oAClv7cAAAAXAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAK02nAAAAAAAAAAA5eQ72ImogcJC0r/E4iduW9aG8B1X2M4XO5KeAPx8ALgAAAAXPu12oAClv7cAAAAYAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAArTacAAAAAAAAAAB9vHvww2Qsarw4yq0Hf+RN6dFIKyd0ggHqrLBMjrq7XwAAAAABMS0AAK02nAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMArTacAAAAAAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A/HwAuAAAABc+7XagAKW/twAAABgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEArTacAAAAAAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A/HwAuAAAABc9vEmgAKW/twAAABgAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:31 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:32 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17175'
+      X-Ratelimit-Reset:
+      - '994'
+      Content-Length:
+      - '2345'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG",
+          "paging_token": "",
+          "account_id": "GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG",
+          "sequence": "48755214613741568",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "2.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG",
+              "weight": 1,
+              "key": "GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:32 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAH28e%2FDDZCxqvDjKrQd%2F5E3p0UgrJ3SCAeqssEyOurtfAAAAZACtNpwAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDVAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A%2FHwAuH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAGOurtfAAAAQG4EAGkFkKkVTsYI7Czrd6u8N0lDI0FnZCMkg1VibRJxmaPwudZFGALSX8q5oIWGLiRyap%2BxT5cxd49hDsCIlgs%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:36 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17165'
+      X-Ratelimit-Reset:
+      - '1087'
+      Content-Length:
+      - '1353'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/297510af38ab807be4b86bcb6ce6595837f5ce7501dca3e10f943bba960ba291"
+            }
+          },
+          "hash": "297510af38ab807be4b86bcb6ce6595837f5ce7501dca3e10f943bba960ba291",
+          "ledger": 11351709,
+          "envelope_xdr": "AAAAAH28e/DDZCxqvDjKrQd/5E3p0UgrJ3SCAeqssEyOurtfAAAAZACtNpwAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDVAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A/HwAuH//////////AAAAAAAAAAGOurtfAAAAQG4EAGkFkKkVTsYI7Czrd6u8N0lDI0FnZCMkg1VibRJxmaPwudZFGALSX8q5oIWGLiRyap+xT5cxd49hDsCIlgs=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAK02nQAAAAAAAAAAfbx78MNkLGq8OMqtB3/kTenRSCsndIIB6qywTI66u18AAAAAATEsnACtNpwAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAK02nQAAAAAAAAAAfbx78MNkLGq8OMqtB3/kTenRSCsndIIB6qywTI66u18AAAAAATEsnACtNpwAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAArTadAAAAAQAAAAB9vHvww2Qsarw4yq0Hf+RN6dFIKyd0ggHqrLBMjrq7XwAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAMArTadAAAAAAAAAAB9vHvww2Qsarw4yq0Hf+RN6dFIKyd0ggHqrLBMjrq7XwAAAAABMSycAK02nAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEArTadAAAAAAAAAAB9vHvww2Qsarw4yq0Hf+RN6dFIKyd0ggHqrLBMjrq7XwAAAAABMSycAK02nAAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:36 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:37 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17164'
+      X-Ratelimit-Reset:
+      - '1083'
+      Content-Length:
+      - '2348'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "paging_token": "",
+          "account_id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "sequence": "46654163857178648",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "9981.9997600",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "weight": 1,
+              "key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:37 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAOXkO9iJqIHCQtK%2FxOInblvWhvAdV9jOFzuSngD8fAC4AAAAZAClv7cAAAAZAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA8qL6w6ZX0eOOnPlnbUhTURNESgZ5nc98rVoUxP0hwawAAAAAATEtAAAAAAAAAAAB%2FHwAuAAAAEBoYS8OuR5wpVKN1%2B5mnX1Ac6cp5mu5CItr1pm3pVt8sdoENgoZ%2FBGioRWOcWpbK3PFbN7ZQqK0Q1tlwbehgBgF
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:40 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17174'
+      X-Ratelimit-Reset:
+      - '989'
+      Content-Length:
+      - '1309'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/75e776dcc2676c6ddd20906c5424112030cbda715ce17eccc41c75778bf3c3d8"
+            }
+          },
+          "hash": "75e776dcc2676c6ddd20906c5424112030cbda715ce17eccc41c75778bf3c3d8",
+          "ledger": 11351710,
+          "envelope_xdr": "AAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAZAClv7cAAAAZAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA8qL6w6ZX0eOOnPlnbUhTURNESgZ5nc98rVoUxP0hwawAAAAAATEtAAAAAAAAAAAB/HwAuAAAAEBoYS8OuR5wpVKN1+5mnX1Ac6cp5mu5CItr1pm3pVt8sdoENgoZ/BGioRWOcWpbK3PFbN7ZQqK0Q1tlwbehgBgF",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAK02ngAAAAAAAAAA5eQ72ImogcJC0r/E4iduW9aG8B1X2M4XO5KeAPx8ALgAAAAXPbxJPAClv7cAAAAYAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAK02ngAAAAAAAAAA5eQ72ImogcJC0r/E4iduW9aG8B1X2M4XO5KeAPx8ALgAAAAXPbxJPAClv7cAAAAZAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAArTaeAAAAAAAAAADyovrDplfR446c+WdtSFNRE0RKBnmdz3ytWhTE/SHBrAAAAAABMS0AAK02ngAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMArTaeAAAAAAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A/HwAuAAAABc9vEk8AKW/twAAABkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEArTaeAAAAAAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A/HwAuAAAABc8ixw8AKW/twAAABkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:41 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:41 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17173'
+      X-Ratelimit-Reset:
+      - '985'
+      Content-Length:
+      - '2345'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4",
+          "paging_token": "",
+          "account_id": "GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4",
+          "sequence": "48755223203676160",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "2.0000000",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4",
+              "weight": 1,
+              "key": "GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:42 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAPKi%2BsOmV9Hjjpz5Z21IU1ETREoGeZ3PfK1aFMT9IcGsAAAAZACtNp4AAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDVAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A%2FHwAuH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAH9IcGsAAAAQJssOuXphOaLMfHZ1KMJviJOsX%2BMkyNDlNABRPFvyGnuM5pMtUkwP6bg6l%2BKyQNXQG2OmFiw%2FV6BWa5MA565uQA%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:45 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17172'
+      X-Ratelimit-Reset:
+      - '984'
+      Content-Length:
+      - '1353'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/bb6f649d6c516708d16cbe5da8613ca2b35a0793785a9b0e6c57d868ebc5bb60"
+            }
+          },
+          "hash": "bb6f649d6c516708d16cbe5da8613ca2b35a0793785a9b0e6c57d868ebc5bb60",
+          "ledger": 11351711,
+          "envelope_xdr": "AAAAAPKi+sOmV9Hjjpz5Z21IU1ETREoGeZ3PfK1aFMT9IcGsAAAAZACtNp4AAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABQlRDVAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A/HwAuH//////////AAAAAAAAAAH9IcGsAAAAQJssOuXphOaLMfHZ1KMJviJOsX+MkyNDlNABRPFvyGnuM5pMtUkwP6bg6l+KyQNXQG2OmFiw/V6BWa5MA565uQA=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAK02nwAAAAAAAAAA8qL6w6ZX0eOOnPlnbUhTURNESgZ5nc98rVoUxP0hwawAAAAAATEsnACtNp4AAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAK02nwAAAAAAAAAA8qL6w6ZX0eOOnPlnbUhTURNESgZ5nc98rVoUxP0hwawAAAAAATEsnACtNp4AAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAArTafAAAAAQAAAADyovrDplfR446c+WdtSFNRE0RKBnmdz3ytWhTE/SHBrAAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAMArTafAAAAAAAAAADyovrDplfR446c+WdtSFNRE0RKBnmdz3ytWhTE/SHBrAAAAAABMSycAK02ngAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEArTafAAAAAAAAAADyovrDplfR446c+WdtSFNRE0RKBnmdz3ytWhTE/SHBrAAAAAABMSycAK02ngAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:46 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:46 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17171'
+      X-Ratelimit-Reset:
+      - '980'
+      Content-Length:
+      - '2348'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "paging_token": "",
+          "account_id": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+          "sequence": "46654163857178649",
+          "subentry_count": 0,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "9979.9997500",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "weight": 1,
+              "key": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:47 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAOXkO9iJqIHCQtK%2FxOInblvWhvAdV9jOFzuSngD8fAC4AAAAZAClv7cAAAAaAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAfbx78MNkLGq8OMqtB3%2FkTenRSCsndIIB6qywTI66u18AAAABQlRDVAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A%2FHwAuAAAAAABycOAAAAAAAAAAAH8fAC4AAAAQGatCPbx8mXnhgYasdqxHZxB93K0f2TuL2yfjvqSCltOZuKRrb5HySTvnZrX72dfzsQKuN7zJZ%2FXRN9m4HCwEw0%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:51 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17163'
+      X-Ratelimit-Reset:
+      - '1073'
+      Content-Length:
+      - '1305'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/9205527bd3a02a25f5460dd65b82aca07c64407c8b5f160f82a449d72483815a"
+            }
+          },
+          "hash": "9205527bd3a02a25f5460dd65b82aca07c64407c8b5f160f82a449d72483815a",
+          "ledger": 11351712,
+          "envelope_xdr": "AAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAZAClv7cAAAAaAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAAfbx78MNkLGq8OMqtB3/kTenRSCsndIIB6qywTI66u18AAAABQlRDVAAAAADl5DvYiaiBwkLSv8TiJ25b1obwHVfYzhc7kp4A/HwAuAAAAAABycOAAAAAAAAAAAH8fAC4AAAAQGatCPbx8mXnhgYasdqxHZxB93K0f2TuL2yfjvqSCltOZuKRrb5HySTvnZrX72dfzsQKuN7zJZ/XRN9m4HCwEw0=",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAK02oAAAAAAAAAAA5eQ72ImogcJC0r/E4iduW9aG8B1X2M4XO5KeAPx8ALgAAAAXPIsb2AClv7cAAAAZAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAK02oAAAAAAAAAAA5eQ72ImogcJC0r/E4iduW9aG8B1X2M4XO5KeAPx8ALgAAAAXPIsb2AClv7cAAAAaAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAMArTadAAAAAQAAAAB9vHvww2Qsarw4yq0Hf+RN6dFIKyd0ggHqrLBMjrq7XwAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAEArTagAAAAAQAAAAB9vHvww2Qsarw4yq0Hf+RN6dFIKyd0ggHqrLBMjrq7XwAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAHJw4B//////////wAAAAEAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:51 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:52 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17162'
+      X-Ratelimit-Reset:
+      - '1068'
+      Content-Length:
+      - '1574'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}",
+              "templated": true
+            },
+            "account_transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/{account_id}/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "assets": {
+              "href": "https://horizon-testnet.stellar.org/assets{?asset_code,asset_issuer,cursor,limit,order}",
+              "templated": true
+            },
+            "friendbot": {
+              "href": "https://friendbot.stellar.org/{?addr}",
+              "templated": true
+            },
+            "metrics": {
+              "href": "https://horizon-testnet.stellar.org/metrics"
+            },
+            "order_book": {
+              "href": "https://horizon-testnet.stellar.org/order_book{?selling_asset_type,selling_asset_code,selling_asset_issuer,buying_asset_type,buying_asset_code,buying_asset_issuer,limit}",
+              "templated": true
+            },
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/"
+            },
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/{hash}",
+              "templated": true
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/transactions{?cursor,limit,order}",
+              "templated": true
+            }
+          },
+          "horizon_version": "0.14.2-4c30d59b86f551475a3ac60e5555c0c86ff3cb75",
+          "core_version": "stellar-core 10.0.0 (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
+          "history_latest_ledger": 11351712,
+          "history_elder_ledger": 1,
+          "core_latest_ledger": 11351712,
+          "network_passphrase": "Test SDF Network ; September 2015",
+          "protocol_version": 10
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:52 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:53 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17170'
+      X-Ratelimit-Reset:
+      - '974'
+      Content-Length:
+      - '2659'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG",
+          "paging_token": "",
+          "account_id": "GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG",
+          "sequence": "48755214613741569",
+          "subentry_count": 1,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "3.0000000",
+              "limit": "922337203685.4775807",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTCT",
+              "asset_issuer": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            {
+              "balance": "1.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG",
+              "weight": 1,
+              "key": "GB63Y67QYNSCY2V4HDFK2B374RG6TUKIFMTXJAQB5KWLATEOXK5V6WZG",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:53 GMT
+- request:
+    method: post
+    uri: https://horizon-testnet.stellar.org/transactions
+    body:
+      encoding: UTF-8
+      string: tx=AAAAAH28e%2FDDZCxqvDjKrQd%2F5E3p0UgrJ3SCAeqssEyOurtfAAAAZACtNpwAAAACAAAAAAAAAAEAAAAEQUJBQwAAAAEAAAAAAAAAAQAAAADyovrDplfR446c%2BWdtSFNRE0RKBnmdz3ytWhTE%2FSHBrAAAAAFCVENUAAAAAOXkO9iJqIHCQtK%2FxOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAAHoSAAAAAAAAAAAY66u18AAABAzuAdeW8d1N6eZP6yTZXX64dcIpJve9j6Zc9l9FzgQZtp%2Bs5OMZc7DCKpgRifqP%2BeCxmjFEai%2Fhi19U7EW%2FDDCA%3D%3D
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:55 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17169'
+      X-Ratelimit-Reset:
+      - '973'
+      Content-Length:
+      - '1637'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "transaction": {
+              "href": "https://horizon-testnet.stellar.org/transactions/c493dd02c2ce5e61213025893ebec832ba5f22567b0694fb9eee42957e865785"
+            }
+          },
+          "hash": "c493dd02c2ce5e61213025893ebec832ba5f22567b0694fb9eee42957e865785",
+          "ledger": 11351713,
+          "envelope_xdr": "AAAAAH28e/DDZCxqvDjKrQd/5E3p0UgrJ3SCAeqssEyOurtfAAAAZACtNpwAAAACAAAAAAAAAAEAAAAEQUJBQwAAAAEAAAAAAAAAAQAAAADyovrDplfR446c+WdtSFNRE0RKBnmdz3ytWhTE/SHBrAAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAAHoSAAAAAAAAAAAY66u18AAABAzuAdeW8d1N6eZP6yTZXX64dcIpJve9j6Zc9l9FzgQZtp+s5OMZc7DCKpgRifqP+eCxmjFEai/hi19U7EW/DDCA==",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAK02oQAAAAAAAAAAfbx78MNkLGq8OMqtB3/kTenRSCsndIIB6qywTI66u18AAAAAATEsOACtNpwAAAABAAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAK02oQAAAAAAAAAAfbx78MNkLGq8OMqtB3/kTenRSCsndIIB6qywTI66u18AAAAAATEsOACtNpwAAAACAAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMArTagAAAAAQAAAAB9vHvww2Qsarw4yq0Hf+RN6dFIKyd0ggHqrLBMjrq7XwAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAHJw4B//////////wAAAAEAAAAAAAAAAAAAAAEArTahAAAAAQAAAAB9vHvww2Qsarw4yq0Hf+RN6dFIKyd0ggHqrLBMjrq7XwAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAHCImB//////////wAAAAEAAAAAAAAAAAAAAAMArTafAAAAAQAAAADyovrDplfR446c+WdtSFNRE0RKBnmdz3ytWhTE/SHBrAAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAEArTahAAAAAQAAAADyovrDplfR446c+WdtSFNRE0RKBnmdz3ytWhTE/SHBrAAAAAFCVENUAAAAAOXkO9iJqIHCQtK/xOInblvWhvAdV9jOFzuSngD8fAC4AAAAAAAHoSB//////////wAAAAEAAAAAAAAAAA=="
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:56 GMT
+- request:
+    method: get
+    uri: https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept:
+      - application/hal+json,application/problem+json,application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/hal+json; charset=utf-8
+      Date:
+      - Tue, 02 Oct 2018 14:18:56 GMT
+      Vary:
+      - Origin
+      X-Ratelimit-Limit:
+      - '17200'
+      X-Ratelimit-Remaining:
+      - '17168'
+      X-Ratelimit-Reset:
+      - '970'
+      Content-Length:
+      - '2659'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4"
+            },
+            "transactions": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/transactions{?cursor,limit,order}",
+              "templated": true
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "payments": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/payments{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "offers": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/offers{?cursor,limit,order}",
+              "templated": true
+            },
+            "trades": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/trades{?cursor,limit,order}",
+              "templated": true
+            },
+            "data": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4/data/{key}",
+              "templated": true
+            }
+          },
+          "id": "GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4",
+          "paging_token": "",
+          "account_id": "GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4",
+          "sequence": "48755223203676161",
+          "subentry_count": 1,
+          "thresholds": {
+            "low_threshold": 0,
+            "med_threshold": 0,
+            "high_threshold": 0
+          },
+          "flags": {
+            "auth_required": false,
+            "auth_revocable": false
+          },
+          "balances": [
+            {
+              "balance": "0.0500000",
+              "limit": "922337203685.4775807",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "credit_alphanum4",
+              "asset_code": "BTCT",
+              "asset_issuer": "GDS6IO6YRGUIDQSC2K74JYRHNZN5NBXQDVL5RTQXHOJJ4AH4PQALQWPR"
+            },
+            {
+              "balance": "1.9999900",
+              "buying_liabilities": "0.0000000",
+              "selling_liabilities": "0.0000000",
+              "asset_type": "native"
+            }
+          ],
+          "signers": [
+            {
+              "public_key": "GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4",
+              "weight": 1,
+              "key": "GDZKF6WDUZL5DY4OTT4WO3KIKNIRGRCKAZ4Z3T34VVNBJRH5EHA2YQY4",
+              "type": "ed25519_public_key"
+            }
+          ],
+          "data": {}
+        }
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 14:18:57 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/stellar_base_spec.rb
+++ b/spec/lib/stellar_base_spec.rb
@@ -1,8 +1,41 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe StellarBase do
-
   describe "configuration" do
+    describe "stellar_network" do
+      context "no supplied network" do
+        it "defaults to testnet" do
+          expect(Stellar.current_network).to eq Stellar::Networks::TESTNET
+        end
+      end
+
+      context "invalid network" do
+        after do
+          described_class.configuration.stellar_network = "testnet"
+        end
+
+        it "raises error" do
+          expect {
+            described_class.configuration.stellar_network = "etc"
+          }.to raise_error(
+            ArgumentError,
+            "'etc' not a valid stellar_network config",
+          )
+        end
+      end
+
+      context "supplied network" do
+        after do
+          described_class.configuration.stellar_network = "testnet"
+        end
+
+        it "defaults to testnet" do
+          described_class.configuration.stellar_network = "public"
+          expect(Stellar.current_network).to eq Stellar::Networks::PUBLIC
+        end
+      end
+    end
+
     describe "withdraw" do
       it "accepts a Ruby hash" do
         described_class.configuration.withdrawable_assets = [
@@ -12,7 +45,7 @@ RSpec.describe StellarBase do
             asset_code: "ETH",
             issuer: "issuer-address",
             fee_fixed: 0.1,
-          }
+          },
         ]
 
         config = described_class.configuration.withdrawable_assets
@@ -27,7 +60,7 @@ RSpec.describe StellarBase do
             asset_code: "ETH",
             issuer: "issuer-address",
             fee_fixed: 0.1,
-          }
+          },
         ].to_json
 
         config = described_class.configuration.withdrawable_assets
@@ -43,5 +76,4 @@ RSpec.describe StellarBase do
       end
     end
   end
-
 end

--- a/spec/services/stellar_base/deposit_requests/create_deposit_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/create_deposit_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe CreateDeposit do
+      let!(:deposit_request) { create(:stellar_base_deposit_request) }
+
+      it "skips remaining actions" do
+        deposit = described_class.execute(
+          deposit_request: deposit_request,
+          amount: 0.0513,
+          tx_id: "2dc",
+        ).deposit
+
+        expect(deposit).to be_persisted
+        expect(deposit.tx_id).to eq "2dc"
+        expect(deposit.amount).to eq 0.0513
+        expect(deposit.deposit_request_id).to eq deposit_request.id
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/find_config_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/find_config_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe FindConfig do
+      context "config exists" do
+        it "sets deposit_config on the context" do
+          config = described_class.execute(network: "bitcoin").deposit_config
+          expect(config[:network]).to eq "bitcoin"
+          expect(config[:asset_code]).to eq "BTCT"
+        end
+      end
+
+      context "config does not exist" do
+        it "sets deposit_config to nil" do
+          result = described_class.execute(network: "eth")
+          expect(result).to be_failure
+          expect(result.deposit_config).to be_nil
+          expect(result.message).to eq "No depositable_asset config for eth"
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/find_deposit_request_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/find_deposit_request_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe FindDepositRequest do
+      context "deposit request exists" do
+        let!(:deposit_request) do
+          create(:stellar_base_deposit_request, {
+            asset_code: "BTCT",
+            deposit_address: "1bc",
+          })
+        end
+        let(:deposit_config) do
+          FindConfig.execute(network: "bitcoin").deposit_config
+        end
+
+        it "sets deposit_request on the context" do
+          resulting_ctx = described_class.execute(
+            deposit_config: deposit_config,
+            deposit_address: "1bc",
+          )
+
+          expect(resulting_ctx.deposit_request).to eq deposit_request
+        end
+      end
+
+      context "deposit request does not exist" do
+        let(:deposit_config) do
+          FindConfig.execute(network: "bitcoin").deposit_config
+        end
+
+        it "does nothing" do
+          result = described_class.execute(
+            deposit_config: deposit_config,
+            deposit_address: "1bc",
+          )
+
+          expect(result).to be_failure
+          expect(result.message).to eq "No DepositRequest found for BTCT:1bc"
+
+          deposit_request = result.deposit_request
+
+          expect(deposit_request).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/find_deposit_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/find_deposit_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe FindDeposit do
+      let!(:deposit_request) do
+        create(:stellar_base_deposit_request, {
+          asset_code: "BTCT",
+          deposit_address: "1bc",
+        })
+      end
+      let(:ctxt) do
+        LightService::Context.new(
+          deposit_request: deposit_request,
+          tx_id: "2dc",
+        )
+      end
+
+      context "deposit exists" do
+        let!(:deposit) do
+          create(:stellar_base_deposit, {
+            tx_id: "2dc",
+            deposit_request: deposit_request,
+          })
+        end
+
+        it "skips remaining actions" do
+          expect(ctxt).to receive(:skip_remaining!)
+          result = described_class.execute(ctxt)
+          expect(result.deposit).to be_present
+        end
+      end
+
+      context "deposit does not exist" do
+        it "does not call skip_remaining" do
+          expect(ctxt).not_to receive(:skip_remaining!)
+          result = described_class.execute(ctxt)
+          expect(result.deposit).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/init_stellar_amount_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/init_stellar_amount_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe InitStellarAmount do
+      let(:stellar_issuer) { Stellar::Account.random }
+      let(:stellar_asset) do
+        Stellar::Asset.alphanum4("BTC", stellar_issuer.keypair)
+      end
+
+      it "sets the stellar_amount in the context" do
+        resulting_ctx = described_class.execute(
+          stellar_asset: stellar_asset,
+          amount: 1.5,
+        )
+        amount = resulting_ctx.stellar_amount
+
+        expect(amount.amount).to eq 1.5
+        expect(amount.asset).to eq stellar_asset
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/init_stellar_asset_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/init_stellar_asset_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe InitStellarAsset do
+      let(:issuing_account) { Stellar::Account.random }
+      let(:deposit_request) do
+        build_stubbed(:stellar_base_deposit_request, asset_code: "BTCT")
+      end
+
+      it "sets the stellar_asset in the context" do
+        resulting_ctx = described_class.execute(
+          issuer_account: issuing_account,
+          deposit_request: deposit_request,
+        )
+        asset = resulting_ctx.stellar_asset
+
+        expect(asset.code).to eq "BTCT"
+        expect(asset.issuer).to eq issuing_account.keypair.public_key
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/init_stellar_distribution_account_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/init_stellar_distribution_account_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe InitStellarDistributionAccount do
+      let(:distribution_account) { Stellar::Account.random }
+      let(:deposit_config) do
+        FindConfig.execute(network: "bitcoin").deposit_config
+      end
+
+      it "sets the stellar_asset in the context" do
+        resulting_ctx = described_class.execute(deposit_config: deposit_config)
+        account = resulting_ctx.distribution_account
+
+        expect(account.address).to eq deposit_config[:distributor]
+        expect(account.keypair.seed).to eq deposit_config[:distributor_seed]
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/init_stellar_issuer_account_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/init_stellar_issuer_account_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe InitStellarIssuerAccount do
+      let(:deposit_config) do
+        FindConfig.execute(network: "bitcoin").deposit_config
+      end
+
+      it "sets the stellar_issuer_account in the context" do
+        resulting_ctx = described_class.execute(deposit_config: deposit_config)
+        account = resulting_ctx.issuer_account
+
+        expect(account).to be_a Stellar::Account
+        expect(account.address).to eq deposit_config[:issuer]
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/init_stellar_recipient_account_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/init_stellar_recipient_account_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe InitStellarRecipientAccount do
+      let(:deposit_request) do
+        build_stubbed(:stellar_base_deposit_request, {
+          account_id: Stellar::Account.random.address,
+        })
+      end
+
+      it "sets the stellar_recipient_account in the context" do
+        result = described_class.execute(deposit_request: deposit_request)
+        account = result.recipient_account
+
+        expect(account).to be_a Stellar::Account
+        expect(account.address).to eq deposit_request.account_id
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/send_asset_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/send_asset_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe SendAsset do
+      context "no errors" do
+        let(:client) { InitStellarClient.execute.stellar_client }
+        let(:deposit_request) do
+          build_stubbed(:stellar_base_deposit_request, memo: "ABC")
+        end
+        let(:distribution_account) { Stellar::Account.random }
+        let(:recipient_account) { Stellar::Account.random }
+        let(:stellar_amount) { Stellar::Amount.native(1.0) }
+
+        it "sends the client" do
+          expect(stellar_client).to receive(:send_payment).with(
+            from: distribution_account,
+            to: recipient,
+            amount: stellar_amount,
+            memo: "ABC",
+          )
+
+          described_class.execute(
+            recipient_account: stellar_recipient_account,
+            distribution_account: stellar_distribution_account,
+            stellar_amount: stellar_amount,
+            stellar_sdk_client: client,
+          )
+        end
+      end
+
+      context "there are errors" do
+        let(:stellar_client) { InitStellarClient.execute.stellar_client }
+        let(:stellar_distribution_account) { Stellar::Account.random }
+        let(:stellar_amount) { Stellar::Amount.native(1.0) }
+        let(:deposit_request) do
+          build_stubbed(:stellar_base_deposit_request, memo: "ABC")
+        end
+        let(:error) { Faraday::ClientError.new("message") }
+
+        it "sends the client" do
+          expect(stellar_client).to receive(:send_payment).with(
+            from: account,
+            to: recipient,
+            amount: stellar_amount,
+            memo: "ABC",
+          ).and_raise(error)
+
+          resulting_ctx = described_class.execute(
+            stellar_recipient_account: stellar_recipient_account,
+            stellar_distribution_account: stellar_distribution_account,
+            stellar_amount: stellar_amount,
+            stellar_client: stellar_client,
+          )
+
+          expect(resulting_ctx).to be_failure
+          expect(resulting_ctx).to be_skip_remaining
+          expect(resulting_ctx.message)
+            .to eq "Error sending the asset. Faraday::ClientError: message"
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/trigger_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/trigger_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe Trigger do
+      it "executes actions in order" do
+        actions = [
+          FindConfig,
+          FindDepositRequest,
+          FindDeposit,
+          CreateDeposit,
+          InitStellarClient,
+          InitStellarIssuerAccount,
+          InitStellarRecipientAccount,
+          InitStellarDistributionAccount,
+          InitStellarAsset,
+          InitStellarAmount,
+          SendAsset,
+          UpdateDeposit,
+        ]
+
+        ctx = LightService::Context.new(
+          network: "bitcoin",
+          deposit_address: "btc-address",
+          tx_id: "1b3",
+          amount: 1.0,
+        )
+
+        actions.each do |action|
+          expect(action).to receive(:execute).with(ctx).and_return(ctx)
+        end
+
+        described_class.("bitcoin", "btc-address", "1b3", 1.0)
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/init_stellar_client_spec.rb
+++ b/spec/services/stellar_base/init_stellar_client_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+module StellarBase
+  RSpec.describe InitStellarClient do
+    it "initializes the Stellar SDK client in the context" do
+      result = described_class.execute
+      client = result.stellar_sdk_client
+
+      expect(client).to be_a Stellar::Client
+      expect(client.horizon._url).to eq StellarBase.configuration.horizon_url
+    end
+  end
+end

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -31,7 +31,7 @@ RSpec.configure do |c|
           network: "bitcoin",
           asset_code: "BTCT",
           issuer: CONFIG[:issuer_address],
-          distributor: CONFIG[:distributor],
+          distributor: CONFIG[:distributor_address],
           distributor_seed: CONFIG[:distributor_seed],
           how_from: GetHow.to_s,
           max_amount_from: GetMaxAmount.to_s,

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -5,15 +5,15 @@ CONFIG[:distributor] = Stellar::Account.random
 RSpec.configure do |c|
   c.before(:each) do
     StellarBase.configure do |c|
-      c.modules = %i[bridge_callbacks withdraw deposit]
-      c.horizon_url = "https://horizon-testnet.stellar.org"
-
-      c.distribution_account = "G-DISTRO-ACCOUNT"
-
-      c.on_bridge_callback = "ProcessBridgeCallback"
+      c.bridge_callbacks_mac_key = "sample"
       c.check_bridge_callbacks_authenticity = false
       c.check_bridge_callbacks_mac_payload = false
-      c.bridge_callbacks_mac_key = "sample"
+      c.distribution_account = "G-DISTRO-ACCOUNT"
+      c.horizon_url = "https://horizon-testnet.stellar.org"
+      c.modules = %i[bridge_callbacks withdraw deposit]
+      c.on_bridge_callback = "ProcessBridgeCallback"
+      c.on_withdraw = ProcessWithdrawal.to_s
+      c.stellar_toml = { TRANSFER_SERVER: "http://example.com/stellar" }
 
       c.withdrawable_assets = [
         {
@@ -37,8 +37,6 @@ RSpec.configure do |c|
           max_amount_from: GetMaxAmount.to_s,
         },
       ]
-      c.on_withdraw = ProcessWithdrawal.to_s
-      c.stellar_toml = { TRANSFER_SERVER: "http://example.com/stellar" }
     end
   end
 end

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -1,6 +1,5 @@
 CONFIG = YAML.load_file(SPEC_DIR.join("config.yml")).with_indifferent_access
 CONFIG[:issuer_address] = Stellar::Account.random.address
-CONFIG[:distributor] = Stellar::Account.random
 
 RSpec.configure do |c|
   c.before(:each) do
@@ -14,6 +13,7 @@ RSpec.configure do |c|
       c.on_bridge_callback = "ProcessBridgeCallback"
       c.on_withdraw = ProcessWithdrawal.to_s
       c.stellar_toml = { TRANSFER_SERVER: "http://example.com/stellar" }
+      c.stellar_network = "testnet"
 
       c.withdrawable_assets = [
         {
@@ -31,8 +31,8 @@ RSpec.configure do |c|
           network: "bitcoin",
           asset_code: "BTCT",
           issuer: CONFIG[:issuer_address],
-          distributor: CONFIG[:distributor].address,
-          distributor_seed: CONFIG[:distributor].keypair.seed,
+          distributor: CONFIG[:distributor],
+          distributor_seed: CONFIG[:distributor_seed],
           how_from: GetHow.to_s,
           max_amount_from: GetMaxAmount.to_s,
         },

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -1,5 +1,6 @@
 CONFIG = YAML.load_file(SPEC_DIR.join("config.yml")).with_indifferent_access
 CONFIG[:issuer_address] = Stellar::Account.random.address
+CONFIG[:distributor] = Stellar::Account.random
 
 RSpec.configure do |c|
   c.before(:each) do
@@ -30,8 +31,8 @@ RSpec.configure do |c|
           network: "bitcoin",
           asset_code: "BTCT",
           issuer: CONFIG[:issuer_address],
-          distributor: "G-DISTRO-ACCOUNT",
-          distributor_seed: "S-DISTRO_ACCOUNT_SEED",
+          distributor: CONFIG[:distributor].address,
+          distributor_seed: CONFIG[:distributor].keypair.seed,
           how_from: GetHow.to_s,
           max_amount_from: GetMaxAmount.to_s,
         },


### PR DESCRIPTION
This PR allows `stellar_base-rails` users to easily send the Stellar Asset to the account of someone who requested for a `Deposit`

- Add a `StellarBase.on_deposit_trigger(network, deposit_address, tx_id, amount)`
- Add a `StellarBase.configuration.stellar_network`