### PR TITLE
Add the complete stellar_toml attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Add all attributes for a complete stellar_toml file
+
+### Fixed
+- Fix `LocalJumpError` issues for Rails apps that already have the `toml` mime type registered
+
 ## [0.7.0]
 ### Added
 - Add `StellarBase.on_deposit_trigger`

--- a/app/models/stellar_base/stellar_toml.rb
+++ b/app/models/stellar_base/stellar_toml.rb
@@ -3,7 +3,42 @@ module StellarBase
 
     include Virtus.model
 
-    attribute :TRANSFER_SERVER, String, default: ""
+    attribute :ACCOUNTS, Array
+    attribute :AUTH_SERVER, String
+    attribute :CURRENCIES, Array
+    attribute :DESIRED_BASE_FEE, Integer
+    attribute :DESIRED_MAX_TX_PER_LEDGER, Integer
+    attribute :FEDERATION_SERVER, String
+    attribute :HISTORY, Array
+    attribute :KNOWN_PEERS, Array
+    attribute :NODE_NAMES, Array
+    attribute :OUR_VALIDATORS, Array
+    attribute :QUORUM_SET, Array
+    attribute :SIGNING_KEY, String
+    attribute :TRANSFER_SERVER, String
+
+    ATTRIBUTES = %w[
+      ACCOUNTS
+      AUTH_SERVER
+      CURRENCIES
+      DESIRED_BASE_FEE
+      DESIRED_MAX_TX_PER_LEDGER
+      FEDERATION_SERVER
+      HISTORY
+      KNOWN_PEERS
+      NODE_NAMES
+      OUR_VALIDATORS
+      QUORUM_SET
+      SIGNING_KEY
+      TRANSFER_SERVER
+    ].freeze
+
+    def to_hash
+      ATTRIBUTES.each_with_object({}) do |attr, hash|
+        value = send(attr)
+        hash[attr] = send(attr) if value.present?
+      end
+    end
 
   end
 end

--- a/app/services/stellar_base/deposit_requests/send_asset.rb
+++ b/app/services/stellar_base/deposit_requests/send_asset.rb
@@ -24,15 +24,20 @@ module StellarBase
 
         Rails.logger.info(msg)
 
-        # TODO: handle when this fails
-        response = c.stellar_sdk_client.send_payment(
-          from: c.distribution_account,
-          to: c.recipient_account,
-          amount: c.stellar_amount,
-          memo: c.deposit_request.memo,
-        )
+        begin
+          response = c.stellar_sdk_client.send_payment(
+            from: c.distribution_account,
+            to: c.recipient_account,
+            amount: c.stellar_amount,
+            memo: c.deposit_request.memo,
+          )
 
-        c.stellar_tx_id = response.to_hash["hash"]
+          c.stellar_tx_id = response.to_hash["hash"]
+        rescue Faraday::ClientError => e
+          c.fail!
+          c.skip_remaining! "Error sending the asset. " \
+            "Faraday::ClientError: #{e.message}"
+        end
       end
 
     end

--- a/lib/stellar_base/engine.rb
+++ b/lib/stellar_base/engine.rb
@@ -9,8 +9,9 @@ module StellarBase
     end
 
     initializer "register.mime_types" do
-      return if Mime::Type.lookup_by_extension("toml").present?
-      Mime::Type.register "application/toml", :toml
+      if Mime::Type.lookup_by_extension("toml").blank?
+        Mime::Type.register "application/toml", :toml
+      end
     end
 
     config.generators do |g|

--- a/spec/services/stellar_base/deposit_requests/send_asset_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/send_asset_spec.rb
@@ -3,26 +3,35 @@ require "spec_helper"
 module StellarBase
   module DepositRequests
     RSpec.describe SendAsset do
+      let(:distribution_account) { Stellar::Account.random }
+      let(:recipient_account) { Stellar::Account.random }
+      let(:issuer_account) { Stellar::Account.random }
+      let(:client) { InitStellarClient.execute.stellar_sdk_client }
+      let(:deposit_request) do
+        build_stubbed(:stellar_base_deposit_request, memo: "ABC")
+      end
+      let(:stellar_amount) { Stellar::Amount.new(1.0) }
+
       context "no errors" do
-        let(:client) { InitStellarClient.execute.stellar_client }
-        let(:deposit_request) do
-          build_stubbed(:stellar_base_deposit_request, memo: "ABC")
+        let(:response) do
+          double(Hyperclient::Resource, to_hash: {
+            "hash" => "stellar-tx-hash",
+          })
         end
-        let(:distribution_account) { Stellar::Account.random }
-        let(:recipient_account) { Stellar::Account.random }
-        let(:stellar_amount) { Stellar::Amount.native(1.0) }
 
         it "sends the client" do
-          expect(stellar_client).to receive(:send_payment).with(
+          expect(client).to receive(:send_payment).with(
             from: distribution_account,
-            to: recipient,
+            to: recipient_account,
             amount: stellar_amount,
             memo: "ABC",
-          )
+          ).and_return(response)
 
           described_class.execute(
-            recipient_account: stellar_recipient_account,
-            distribution_account: stellar_distribution_account,
+            deposit_request: deposit_request,
+            distribution_account: distribution_account,
+            issuer_account: issuer_account,
+            recipient_account: recipient_account,
             stellar_amount: stellar_amount,
             stellar_sdk_client: client,
           )
@@ -30,32 +39,27 @@ module StellarBase
       end
 
       context "there are errors" do
-        let(:stellar_client) { InitStellarClient.execute.stellar_client }
-        let(:stellar_distribution_account) { Stellar::Account.random }
-        let(:stellar_amount) { Stellar::Amount.native(1.0) }
-        let(:deposit_request) do
-          build_stubbed(:stellar_base_deposit_request, memo: "ABC")
-        end
         let(:error) { Faraday::ClientError.new("message") }
 
         it "sends the client" do
-          expect(stellar_client).to receive(:send_payment).with(
-            from: account,
-            to: recipient,
+          expect(client).to receive(:send_payment).with(
+            from: distribution_account,
+            to: recipient_account,
             amount: stellar_amount,
             memo: "ABC",
           ).and_raise(error)
 
-          resulting_ctx = described_class.execute(
-            stellar_recipient_account: stellar_recipient_account,
-            stellar_distribution_account: stellar_distribution_account,
+          result = described_class.execute(
+            deposit_request: deposit_request,
+            distribution_account: distribution_account,
+            issuer_account: issuer_account,
+            recipient_account: recipient_account,
             stellar_amount: stellar_amount,
-            stellar_client: stellar_client,
+            stellar_sdk_client: client,
           )
 
-          expect(resulting_ctx).to be_failure
-          expect(resulting_ctx).to be_skip_remaining
-          expect(resulting_ctx.message)
+          expect(result).to be_failure
+          expect(result.message)
             .to eq "Error sending the asset. Faraday::ClientError: message"
         end
       end


### PR DESCRIPTION
This PR contains:

- A fix for `LocalJumpError` issues with Rails applications that already have `toml` as a registered mime type
- Support all `stellar_toml` attributes