### PR TITLE
Dont raise exceptions when on_deposit_trigger fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Change error lifting for `StellarBase.on_deposit_trigger`. Raising exception is too expensive
+
 ## [0.8.0]
 ### Added
 - Add `StellarBase.on_account_event` and `.subscribe_to_accounts`

--- a/app/services/stellar_base/deposit_requests/find_deposit.rb
+++ b/app/services/stellar_base/deposit_requests/find_deposit.rb
@@ -13,7 +13,9 @@ module StellarBase
           tx_id: c.tx_id,
         )
 
-        c.skip_remaining! if c.deposit.present?
+        if c.deposit.present?
+          c.skip_remaining!("Deposit trigger previously made, skipping")
+        end
       end
 
     end

--- a/app/services/stellar_base/deposit_requests/find_deposit_request.rb
+++ b/app/services/stellar_base/deposit_requests/find_deposit_request.rb
@@ -17,7 +17,7 @@ module StellarBase
         )
 
         if c.deposit_request.blank?
-          c.fail_and_return! "No DepositRequest found for " +
+          c.skip_remaining! "No DepositRequest found for " +
             [asset_code, deposit_address].join(":")
         end
       end

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -45,9 +45,7 @@ module StellarBase
   end
 
   def self.on_deposit_trigger(network:, deposit_address:, tx_id:, amount:)
-    result = DepositRequests::Trigger.(network, deposit_address, tx_id, amount)
-    raise StandardError, result.message if result.failure?
-    result
+    DepositRequests::Trigger.(network, deposit_address, tx_id, amount)
   end
 
   def self.included_module?(module_name)

--- a/spec/acceptance/on_deposit_trigger_spec.rb
+++ b/spec/acceptance/on_deposit_trigger_spec.rb
@@ -3,27 +3,27 @@ require "spec_helper"
 describe "StellarBase.on_deposit_trigger" do
   context "deposit_config not found" do
     it "skips remaining actions and fails" do
-      expect {
-        StellarBase.on_deposit_trigger(
-          network: "eth",
-          deposit_address: "1bc",
-          tx_id: "",
-          amount: 0.5,
-        )
-      }.to raise_error StandardError, "No depositable_asset config for eth"
+      result = StellarBase.on_deposit_trigger(
+        network: "eth",
+        deposit_address: "1bc",
+        tx_id: "",
+        amount: 0.5,
+      )
+      expect(result).to be_failure
+      expect(result.message).to eq "No depositable_asset config for eth"
     end
   end
 
   context "deposit_request doesn't exist" do
     it "skips remaining actions" do
-      expect {
-        StellarBase.on_deposit_trigger(
-          network: "bitcoin",
-          deposit_address: "1bc",
-          tx_id: "",
-          amount: 0.5,
-        )
-      }.to raise_error StandardError, "No DepositRequest found for BTCT:1bc"
+      result = StellarBase.on_deposit_trigger(
+        network: "bitcoin",
+        deposit_address: "1bc",
+        tx_id: "",
+        amount: 0.5,
+      )
+      expect(result).to be_skip_remaining
+      expect(result.message).to eq "No DepositRequest found for BTCT:1bc"
     end
   end
 
@@ -51,6 +51,8 @@ describe "StellarBase.on_deposit_trigger" do
         amount: 0.5,
       )
 
+      expect(result).to be_skip_remaining
+      expect(result.message).to eq "Deposit trigger previously made, skipping"
       expect(result.deposit.amount).to eq 0.35
       expect(result.deposit.stellar_tx_id).to eq "s12"
       expect(result.deposit.tx_id).to eq "def"

--- a/spec/services/stellar_base/deposit_requests/find_deposit_request_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/find_deposit_request_spec.rb
@@ -35,7 +35,7 @@ module StellarBase
             deposit_address: "1bc",
           )
 
-          expect(result).to be_failure
+          expect(result).to be_skip_remaining
           expect(result.message).to eq "No DepositRequest found for BTCT:1bc"
 
           deposit_request = result.deposit_request


### PR DESCRIPTION
It's too expensive to raise exceptions when a trigger skips or fails steps