### PR TITLE
Default #subscribe_to_accounts config to []

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Remove dependency sidekiq-cron
 
+### Fixed
+- `#subscribe_to_accounts` config defaults to an empty array
+
 ## [0.8.1]
 ### Changed
 - Change error lifting for `StellarBase.on_deposit_trigger`. Raising exception is too expensive

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -29,7 +29,7 @@ module StellarBase
     has :on_bridge_callback
     has :on_withdraw
     has :on_account_event
-    has :subscribe_to_accounts, classes: [NilClass, Array]
+    has :subscribe_to_accounts, classes: [Array], default: []
     has :stellar_network, classes: String, default: "testnet"
     has :stellar_toml, classes: Hash, default: {}
     has :depositable_assets, classes: [NilClass, Array, String, Pathname]


### PR DESCRIPTION
When there are no predetermined accounts to watch, this should not be nil but an empty array, so when it is iterated, the code will not blow up