### PR TITLE
Pass deposit request in how_from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Pass in `GET /deposit` params in `how_from` class
+
 ## [0.9.0] - 2018-10-04
 ### Changed
 - Remove dependency sidekiq-cron

--- a/app/concepts/stellar_base/deposit_requests/operations/create.rb
+++ b/app/concepts/stellar_base/deposit_requests/operations/create.rb
@@ -36,7 +36,7 @@ module StellarBase
         def determine_how!(options, params:, **)
           details = params[:deposit_asset_details]
           options["model"].deposit_address =
-            ConfiguredClassRunner.(details[:how_from])
+            DetermineHow.(details[:how_from], params[:deposit_request])
         end
 
         def determine_max_amount!(options, params:, **)
@@ -67,6 +67,7 @@ module StellarBase
           return GenMemoFor.(DepositRequest) if params[:memo].blank?
           params[:memo]
         end
+
       end
     end
   end

--- a/app/services/stellar_base/account_subscriptions/save_cursor.rb
+++ b/app/services/stellar_base/account_subscriptions/save_cursor.rb
@@ -1,12 +1,14 @@
 module StellarBase
-  class SaveCursor
+  module AccountSubscriptions
+    class SaveCursor
 
-    extend LightService::Action
-    expects :account_subscription, :operations
+      extend LightService::Action
+      expects :account_subscription, :operations
 
-    executed do |c|
-      c.account_subscription.update_attributes!(cursor: c.operations.last.id)
+      executed do |c|
+        c.account_subscription.update!(cursor: c.operations.last.id)
+      end
+
     end
-
   end
 end

--- a/app/services/stellar_base/deposit_requests/determine_how.rb
+++ b/app/services/stellar_base/deposit_requests/determine_how.rb
@@ -1,0 +1,15 @@
+module StellarBase
+  module DepositRequests
+    class DetermineHow
+
+      DEFAULT = nil
+
+      def self.call(class_name, params)
+        # TODO: how do we handle errors
+        return class_name.constantize.send(:call, params) if class_name.present?
+        DEFAULT
+      end
+
+    end
+  end
+end

--- a/app/services/stellar_base/deposit_requests/determine_how.rb
+++ b/app/services/stellar_base/deposit_requests/determine_how.rb
@@ -6,7 +6,13 @@ module StellarBase
 
       def self.call(class_name, params)
         # TODO: how do we handle errors
-        return class_name.constantize.send(:call, params) if class_name.present?
+        if class_name.present?
+          unless class_name.constantize.method(:call).arity.zero?
+            return class_name.constantize.send(:call, params)
+          end
+
+          return class_name.constantize.send(:call)
+        end
         DEFAULT
       end
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -174,4 +174,4 @@ This engine gives you a method called `StellarBase.on_deposit_trigger` you call 
     - The `max_amount_from` class is expected to implement a `self.call` method. It won't be passed any parameters
   - `how_from` is a class that you define that will run whenever a deposit for that asset is requested. It'll populate the `how` response field. If you don't define anything, it won't run that class and will return `nil` for the `how`
     - The `how_from` class is expected a `String` return.
-    - The `how_from` class is expected to implement a `self.call` method. It won't be passed any parameters
+    - The `how_from` class is expected to implement a `self.call` method. You can implement the `self.call` to accept parameters and it'll be passed the request parameters from `GET /deposit`, the parameters will be in a form of a `Hash`

--- a/spec/concepts/stellar_base/deposit_requests/operations/create_spec.rb
+++ b/spec/concepts/stellar_base/deposit_requests/operations/create_spec.rb
@@ -10,7 +10,15 @@ module StellarBase
               .and_return("MEMO")
             expect(ConfiguredClassRunner).to receive(:call)
               .with(GetMaxAmount.to_s).and_return(100)
-            expect(ConfiguredClassRunner).to receive(:call).with(GetHow.to_s)
+            expect(DetermineHow).to receive(:call)
+              .with(GetHow.to_s, {
+                asset_code: "BTCT",
+                account: "G-STELLAR-ACCOUNT",
+                account_id: "G-STELLAR-ACCOUNT",
+                deposit_type: nil,
+                memo: "MEMO",
+                memo_type: "text",
+              })
               .and_return("BTCADDR")
 
             op = described_class.(deposit_request: {
@@ -25,7 +33,8 @@ module StellarBase
             expect(deposit.asset_type).to eq "crypto"
             expect(deposit.asset_code).to eq "BTCT"
             expect(deposit.account_id).to eq "G-STELLAR-ACCOUNT"
-            expect(deposit.deposit_address).to eq "BTCADDR"
+            expect(deposit.deposit_address)
+              .to eq "BTCADDR"
             expect(deposit.eta).to be_an Integer
             expect(deposit.issuer).to eq CONFIG[:issuer_address]
             expect(deposit.memo_type).to eq "text"

--- a/spec/dummy/app/services/get_how.rb
+++ b/spec/dummy/app/services/get_how.rb
@@ -1,8 +1,8 @@
 class GetHow
 
-  SAMPLE_BTC_ADDRESS = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2k"
+  SAMPLE_BTC_ADDRESS = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2k".freeze
 
-  def self.call
+  def self.call(params)
     SAMPLE_BTC_ADDRESS
   end
 

--- a/spec/dummy/app/services/get_how_no_args.rb
+++ b/spec/dummy/app/services/get_how_no_args.rb
@@ -1,0 +1,9 @@
+class GetHowNoArgs
+
+  SAMPLE_BTC_ADDRESS = "2BD".freeze
+
+  def self.call
+    SAMPLE_BTC_ADDRESS
+  end
+
+end

--- a/spec/models/stellar_base/account_subscription_spec.rb
+++ b/spec/models/stellar_base/account_subscription_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "spec_helper"
 
 module StellarBase
   RSpec.describe AccountSubscription, type: :model do

--- a/spec/services/stellar_base/deposit_requests/determine_how_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/determine_how_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+module StellarBase
+  module DepositRequests
+    RSpec.describe DetermineHow do
+      context "given a class name" do
+        it "runs that class" do
+          expect(GetHow).to receive(:call)
+            .with({ account_id: "GASD" })
+            .and_return(1)
+          described_class.(GetHow.to_s, { account_id: "GASD" })
+        end
+      end
+
+      context "given no class name" do
+        it "returns nil" do
+          expect(described_class.("", { account_id: "GASD" })).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/stellar_base/deposit_requests/determine_how_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/determine_how_spec.rb
@@ -3,12 +3,17 @@ require "spec_helper"
 module StellarBase
   module DepositRequests
     RSpec.describe DetermineHow do
-      context "given a class name" do
+      context "given a class name that needs the params" do
         it "runs that class" do
-          expect(GetHow).to receive(:call)
-            .with({ account_id: "GASD" })
-            .and_return(1)
-          described_class.(GetHow.to_s, { account_id: "GASD" })
+          result = described_class.(GetHow.to_s, { account_id: "GASD" })
+          expect(result).to eq "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2k"
+        end
+      end
+
+      context "given no class name that doesn't need params" do
+        it "returns nil" do
+          result = described_class.(GetHowNoArgs.to_s, { account_id: "GASD" })
+          expect(result).to eq "2BD"
         end
       end
 


### PR DESCRIPTION
**Problem**

STS has no way of providing `crypto-cold-store` a unique code. So it keeps getting the same address.
This is because STS uses `crypto_cold_store_client-ruby` to get addresses. 

https://github.com/bloom-solutions/stellar-token-shifter/blob/master/app/services/deposit/bitcoin/get_address.rb

**Solution** 

Allow a `stellar_base-rails` user to also receive the params from the `GET /deposit` request so they can use the memo for solving things like the Problem above