### PR TITLE
Skip remaining SubscribeAccount actions if an address doesn't have any operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Skip remaining `SubscribeAccount` actions when `operations` cannot be found for an address
+
 ## [0.9.3] - 2018-10-08
 ### Fixed
 - Do not blow up when fetching cursors of non-existent accounts

--- a/app/services/stellar_base/account_subscriptions/get_cursor.rb
+++ b/app/services/stellar_base/account_subscriptions/get_cursor.rb
@@ -13,12 +13,13 @@ module StellarBase
 
         address = c.account_subscription.address
 
-        c.cursor = c.stellar_sdk_client.horizon.
-          account(account_id: address).
-          operations(order: "desc", limit: 1).records.first.id
+        c.cursor = c.stellar_sdk_client.horizon
+          .account(account_id: address)
+          .operations(order: "desc", limit: 1).records.first.id
 
       rescue Faraday::ClientError => e
-        c.fail_and_return! "Skipping fetching cursor of #{address} due to #{e.inspect}"
+        c.fail_and_return! "Skipping fetching cursor of #{address} " \
+          "due to #{e.inspect}"
       end
 
     end

--- a/app/services/stellar_base/account_subscriptions/get_operations.rb
+++ b/app/services/stellar_base/account_subscriptions/get_operations.rb
@@ -17,7 +17,7 @@ module StellarBase
           .operations(order: "asc", limit: c.operation_limit).records
 
         if c.operations.empty?
-          c.skip_remaining! "No operations found " \
+          c.fail_and_return! "No operations found " \
             "for #{c.account_subscription.address}"
         end
       rescue Faraday::ClientError => e

--- a/app/services/stellar_base/account_subscriptions/get_operations.rb
+++ b/app/services/stellar_base/account_subscriptions/get_operations.rb
@@ -12,9 +12,14 @@ module StellarBase
       promises :operations
 
       executed do |c|
-        c.operations = c.stellar_sdk_client.horizon.
-          account(account_id: c.account_subscription.address).
-          operations(order: "asc", limit: c.operation_limit).records
+        c.operations = c.stellar_sdk_client.horizon
+          .account(account_id: c.account_subscription.address)
+          .operations(order: "asc", limit: c.operation_limit).records
+
+        if c.operations.empty?
+          c.skip_remaining! "No operations found " \
+            "for #{c.account_subscription.address}"
+        end
       end
 
     end

--- a/app/services/stellar_base/account_subscriptions/get_operations.rb
+++ b/app/services/stellar_base/account_subscriptions/get_operations.rb
@@ -20,6 +20,9 @@ module StellarBase
           c.skip_remaining! "No operations found " \
             "for #{c.account_subscription.address}"
         end
+      rescue Faraday::ClientError => e
+        c.fail_and_return! "Skipping fetching operations of #{address} " \
+          "due to #{e.inspect}"
       end
 
     end

--- a/app/services/stellar_base/subscribe_account.rb
+++ b/app/services/stellar_base/subscribe_account.rb
@@ -5,10 +5,13 @@ module StellarBase
     OPERATION_LIMIT = 200
 
     def self.call(account_subscription, operation_limit: OPERATION_LIMIT)
-      with(
+      result = with(
         account_subscription: account_subscription,
         operation_limit: operation_limit,
       ).reduce(actions)
+
+      Rails.logger.warn result.message if result.failure?
+      result
     end
 
     def self.actions

--- a/app/services/stellar_base/subscribe_account.rb
+++ b/app/services/stellar_base/subscribe_account.rb
@@ -19,8 +19,8 @@ module StellarBase
         iterate(:operations, [
           AccountSubscriptions::GetTx,
           AccountSubscriptions::ExecuteCallback,
-          AccountSubscriptions::SaveCursor,
         ]),
+        AccountSubscriptions::SaveCursor,
       ]
     end
 

--- a/spec/fixtures/vcr_cassettes/StellarBase_AccountSubscriptions_GetCursor/there_is_no_local_cursor_and_address_has_operations/fetches_the_latest_cursor_latest_operation_id_for_the_account.yml
+++ b/spec/fixtures/vcr_cassettes/StellarBase_AccountSubscriptions_GetCursor/there_is_no_local_cursor_and_address_has_operations/fetches_the_latest_cursor_latest_operation_id_for_the_account.yml
@@ -23,15 +23,15 @@ http_interactions:
       Content-Type:
       - application/hal+json; charset=utf-8
       Date:
-      - Mon, 08 Oct 2018 02:37:50 GMT
+      - Mon, 08 Oct 2018 08:59:04 GMT
       Vary:
       - Origin
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17188'
+      - '17194'
       X-Ratelimit-Reset:
-      - '3037'
+      - '2206'
       Content-Length:
       - '1572'
       Connection:
@@ -78,14 +78,14 @@ http_interactions:
           },
           "horizon_version": "0.14.2-4c30d59b86f551475a3ac60e5555c0c86ff3cb75",
           "core_version": "stellar-core 10.0.0-dbg (1fc018b4f52e8c7e716b023ccf30600af5b4f66d)",
-          "history_latest_ledger": 62536,
+          "history_latest_ledger": 66831,
           "history_elder_ledger": 1,
-          "core_latest_ledger": 62536,
+          "core_latest_ledger": 66832,
           "network_passphrase": "Test SDF Network ; September 2015",
           "protocol_version": 10
         }
     http_version: 
-  recorded_at: Mon, 08 Oct 2018 02:37:51 GMT
+  recorded_at: Mon, 08 Oct 2018 08:59:03 GMT
 - request:
     method: get
     uri: https://horizon-testnet.stellar.org/accounts/GDLBSJG2GIA6OX3TBI7K7BUIZD762NBNKTX5YFJR3WVWQAIUUM23RW3R
@@ -109,15 +109,15 @@ http_interactions:
       Content-Type:
       - application/hal+json; charset=utf-8
       Date:
-      - Mon, 08 Oct 2018 02:37:52 GMT
+      - Mon, 08 Oct 2018 08:59:06 GMT
       Vary:
       - Origin
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17187'
+      - '17191'
       X-Ratelimit-Reset:
-      - '3035'
+      - '1805'
       Content-Length:
       - '2347'
       Connection:
@@ -192,7 +192,7 @@ http_interactions:
           "data": {}
         }
     http_version: 
-  recorded_at: Mon, 08 Oct 2018 02:37:52 GMT
+  recorded_at: Mon, 08 Oct 2018 08:59:05 GMT
 - request:
     method: get
     uri: https://horizon-testnet.stellar.org/accounts/GDLBSJG2GIA6OX3TBI7K7BUIZD762NBNKTX5YFJR3WVWQAIUUM23RW3R/operations?limit=1&order=desc
@@ -216,15 +216,15 @@ http_interactions:
       Content-Type:
       - application/hal+json; charset=utf-8
       Date:
-      - Mon, 08 Oct 2018 02:37:53 GMT
+      - Mon, 08 Oct 2018 08:59:12 GMT
       Vary:
       - Origin
       X-Ratelimit-Limit:
       - '17200'
       X-Ratelimit-Remaining:
-      - '17186'
+      - '17193'
       X-Ratelimit-Reset:
-      - '3034'
+      - '2199'
       Content-Length:
       - '1967'
       Connection:
@@ -279,5 +279,5 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 08 Oct 2018 02:37:53 GMT
+  recorded_at: Mon, 08 Oct 2018 08:59:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/services/stellar_base/account_subscriptions/get_cursor_spec.rb
+++ b/spec/services/stellar_base/account_subscriptions/get_cursor_spec.rb
@@ -1,9 +1,8 @@
-require 'spec_helper'
+require "spec_helper"
 
 module StellarBase
   module AccountSubscriptions
     RSpec.describe GetCursor do
-
       let(:client) { InitStellarClient.execute.stellar_sdk_client }
 
       context "there is a locally saved cursor" do
@@ -24,7 +23,7 @@ module StellarBase
         end
       end
 
-      context "account does not exist", vcr: {record: :once} do
+      context "account does not exist", vcr: { record: :once } do
         let(:account_subscription) do
           create(:stellar_base_account_subscription, address: "ABC")
         end
@@ -48,7 +47,7 @@ module StellarBase
           })
         end
 
-        it "fetches the latest cursor (latest operation id) for the account", vcr: {record: :all} do
+        it "fetches the latest cursor (latest operation id) for the account", vcr: { record: :once } do
           resulting_ctx = described_class.execute(
             account_subscription: account_subscription,
             stellar_sdk_client: client,
@@ -57,7 +56,6 @@ module StellarBase
           expect(resulting_ctx.cursor).to be_present
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
This PR contains the following fixes:

- If a current account doesn't have operations, skip remaining actions
- Log these Faraday errors so that we can keep tabs on failing addresses