### PR TITLE
Fix missing local variable `address`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Missing local variable `address` when `StellarBase::AccountSubscriptions::GetOperations` rescues `Faraday::ClientError` exception
+
 ## [0.9.4] - 2018-10-08
 ### Fixed
 - Skip remaining `SubscribeAccount` actions when `operations` cannot be found for an address

--- a/app/services/stellar_base/account_subscriptions/get_operations.rb
+++ b/app/services/stellar_base/account_subscriptions/get_operations.rb
@@ -12,13 +12,14 @@ module StellarBase
       promises :operations
 
       executed do |c|
+        address = c.account_subscription.address
+
         c.operations = c.stellar_sdk_client.horizon
-          .account(account_id: c.account_subscription.address)
+          .account(account_id: address)
           .operations(order: "asc", limit: c.operation_limit).records
 
         if c.operations.empty?
-          c.fail_and_return! "No operations found " \
-            "for #{c.account_subscription.address}"
+          c.fail_and_return! "No operations found for #{address}"
         end
       rescue Faraday::ClientError => e
         c.fail_and_return! "Skipping fetching operations of #{address} " \


### PR DESCRIPTION
When `StellarBase::AccountSubscriptions::GetOperations` rescues `Faraday::ClientError` exception