### PR TITLE
Optionally use StellarSpectrum to send assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Upgrade stellar-base to `>= 0.18.0`
 
+### Added
+- Optionally use [StellarSpectrum](https://github.com/bloom-solutions/stellar_spectrum-ruby) to send assets
+
 ## [0.10.0] - 2018-11-23
 ### Added
 - Add `balances` module. Which mounts a `/balance/:asset_code` endpoint that returns the `max_amount` of a withdrawable asset

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,11 @@ GEM
       hyperclient (~> 0.7)
       stellar-base (>= 0.18.0)
       toml-rb (~> 1.1, >= 1.1.1)
+    stellar_spectrum (1.0.0)
+      activesupport
+      gem_config
+      redis
+      stellar-sdk (>= 0.6.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     toml-rb (1.1.2)
@@ -331,10 +336,11 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sqlite3
-  stellar-sdk
+  stellar-sdk (>= 0.6.0)
   stellar_base-rails!
+  stellar_spectrum (~> 1.0)
   vcr (~> 4.0)
   webmock
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ https://example.com/stellar/
 https://example.com/
 ```
 
+#### c.sending_strategy
+
+By default, this engine uses [ruby-stellar-sdk](https://github.com/stellar/ruby-stellar-sdk) to send assets. This does not have support for multi-process friendly distribution of assets.
+
+One may opt to use [stellar_spectrum](https://github.com/bloom-solutions/stellar_spectrum-ruby) that allows sending of assets through multiple payment channels.
+
+To configure this:
+
+```ruby
+config = {redis_url: "redis://redis", seeds: %w(S1 S2)}
+c.sending_strategy = [:stellar_spectrum, config]
+```
+
+In the code above, `config` is the [configuration in StellarSpectrum](https://github.com/bloom-solutions/stellar_spectrum-ruby#usage), **except** the `horizon_url`. The value for `horizon_url` will be taken from `c.horizon_url`.
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/app/services/stellar_base/deposit_requests/send_asset.rb
+++ b/app/services/stellar_base/deposit_requests/send_asset.rb
@@ -9,7 +9,7 @@ module StellarBase
         :issuer_account,
         :recipient_account,
         :stellar_amount,
-        :stellar_sdk_client,
+        :asset_sending_client,
       )
       promises :stellar_tx_id
 
@@ -25,7 +25,7 @@ module StellarBase
         Rails.logger.info(msg)
 
         begin
-          response = c.stellar_sdk_client.send_payment(
+          response = c.asset_sending_client.send_payment(
             from: c.distribution_account,
             to: c.recipient_account,
             amount: c.stellar_amount,

--- a/app/services/stellar_base/deposit_requests/trigger.rb
+++ b/app/services/stellar_base/deposit_requests/trigger.rb
@@ -4,12 +4,21 @@ module StellarBase
 
       extend LightService::Organizer
 
-      def self.call(network, deposit_address, tx_id, amount)
+      def self.call(
+        network,
+        deposit_address,
+        tx_id,
+        amount,
+        horizon_url: StellarBase.configuration.horizon_url,
+        sending_strategy: StellarBase.configuration.sending_strategy
+      )
         with(
           network: network,
           deposit_address: deposit_address,
           tx_id: tx_id,
           amount: amount,
+          horizon_url: horizon_url,
+          sending_strategy: sending_strategy,
         ).reduce(actions)
       end
 
@@ -18,7 +27,7 @@ module StellarBase
           FindConfig,
           FindDepositRequest,
           FindOrCreateDeposit,
-          InitStellarClient,
+          InitAssetSendingClient,
           InitStellarIssuerAccount,
           InitStellarRecipientAccount,
           InitStellarDistributionAccount,

--- a/app/services/stellar_base/init_asset_sending_client.rb
+++ b/app/services/stellar_base/init_asset_sending_client.rb
@@ -1,0 +1,21 @@
+module StellarBase
+  class InitAssetSendingClient
+
+    extend LightService::Action
+    expects :sending_strategy, :horizon_url
+    promises :asset_sending_client
+
+    executed do |c|
+      sending_strategy = Array(c.sending_strategy)
+      if sending_strategy.first == :stellar_sdk
+        client = Stellar::Client.new(horizon: c.horizon_url)
+      elsif sending_strategy.first == :stellar_spectrum
+        config = sending_strategy.last.merge(horizon_url: c.horizon_url)
+        client = StellarSpectrum.new(config)
+      end
+
+      c.asset_sending_client = client
+    end
+
+  end
+end

--- a/lib/stellar_base.rb
+++ b/lib/stellar_base.rb
@@ -34,6 +34,7 @@ module StellarBase
     has :stellar_toml, classes: Hash, default: {}
     has :depositable_assets, classes: [NilClass, Array, String, Pathname]
     has :withdrawable_assets, classes: [NilClass, Array, String, Pathname]
+    has :sending_strategy, classes: [Array, Symbol], default: [:stellar_sdk]
   end
 
   after_configuration_change do

--- a/spec/lib/stellar_base_spec.rb
+++ b/spec/lib/stellar_base_spec.rb
@@ -75,5 +75,30 @@ RSpec.describe StellarBase do
         expect(config[1][:issuer]).to eq "G-issuer-on-stellar"
       end
     end
+
+    describe "#sending_strategy" do
+      it "defaults to `:stellar_sdk`" do
+        expect(described_class.configuration.sending_strategy).
+          to match_array([:stellar_sdk])
+      end
+
+      it "can be configured to stellar_sdk" do
+        described_class.configuration.sending_strategy = :stellar_sdk
+
+        expect(described_class.configuration.sending_strategy).
+          to match_array([:stellar_sdk])
+      end
+
+      it "can be configured to stellar_spectrum" do
+        described_class.configuration.sending_strategy = [
+          :stellar_sdk,
+          {
+            redis_url: "redis://localhost",
+            seeds: ["S1", "S2"],
+          }
+        ]
+        expect(described_class.sending_strategy).to eq `:stellar_sdk`
+      end
+    end
   end
 end

--- a/spec/services/stellar_base/deposit_requests/send_asset_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/send_asset_spec.rb
@@ -33,7 +33,7 @@ module StellarBase
             issuer_account: issuer_account,
             recipient_account: recipient_account,
             stellar_amount: stellar_amount,
-            stellar_sdk_client: client,
+            asset_sending_client: client,
           )
         end
       end
@@ -55,7 +55,7 @@ module StellarBase
             issuer_account: issuer_account,
             recipient_account: recipient_account,
             stellar_amount: stellar_amount,
-            stellar_sdk_client: client,
+            asset_sending_client: client,
           )
 
           expect(result).to be_failure

--- a/spec/services/stellar_base/deposit_requests/trigger_spec.rb
+++ b/spec/services/stellar_base/deposit_requests/trigger_spec.rb
@@ -9,7 +9,7 @@ module StellarBase
           FindConfig,
           FindDepositRequest,
           FindOrCreateDeposit,
-          InitStellarClient,
+          InitAssetSendingClient,
           InitStellarIssuerAccount,
           InitStellarRecipientAccount,
           InitStellarDistributionAccount,
@@ -24,13 +24,18 @@ module StellarBase
           deposit_address: "btc-address",
           tx_id: "1b3",
           amount: 1.0,
+          horizon_url: "horizon.com",
+          sending_strategy: [:stellar_sdk],
         )
 
         actions.each do |action|
           expect(action).to receive(:execute).with(ctx).and_return(ctx)
         end
 
-        described_class.("bitcoin", "btc-address", "1b3", 1.0)
+        described_class.("bitcoin", "btc-address", "1b3", 1.0, {
+          horizon_url: "horizon.com",
+          sending_strategy: [:stellar_sdk],
+        })
       end
     end
 

--- a/spec/services/stellar_base/init_asset_sending_client_spec.rb
+++ b/spec/services/stellar_base/init_asset_sending_client_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+module StellarBase
+  RSpec.describe InitAssetSendingClient do
+
+    context "sending_strategy is `:stellar_sdk`" do
+      it "initializes the Stellar SDK client in the context" do
+        result = described_class.execute(
+          sending_strategy: :stellar_sdk,
+          horizon_url: "horizon.com",
+        )
+        client = result.asset_sending_client
+
+        expect(client).to be_a Stellar::Client
+        expect(client.horizon._url).to eq "horizon.com"
+      end
+    end
+
+    context "sending_strategy is `[:stellar_sdk]`" do
+      it "initializes the Stellar SDK client in the context" do
+        result = described_class.execute(
+          sending_strategy: [:stellar_sdk],
+          horizon_url: "horizon.com",
+        )
+        client = result.asset_sending_client
+
+        expect(client).to be_a Stellar::Client
+        expect(client.horizon._url).to eq "horizon.com"
+      end
+    end
+
+    context "sending_strategy is `[:stellar_spectrum, {...}]`" do
+      it "initializes a stellar spectrum client" do
+        result = described_class.execute(
+          sending_strategy: [
+            :stellar_spectrum,
+            {redis_url: "redis://lvh.me", seeds: %w(S1 S2)}
+          ],
+          horizon_url: "horizon.com",
+        )
+        client = result.asset_sending_client
+
+        expect(client).to be_a StellarSpectrum::Client
+        expect(client.redis_url).to eq "redis://lvh.me"
+        expect(client.seeds).to match_array(%w(S1 S2))
+        expect(client.horizon_url).to eq "horizon.com"
+      end
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require "vcr"
 require "rspec/rails"
 require "stellar-sdk"
 require "rspec-sidekiq"
+require "stellar_spectrum"
 
 SPEC_DIR = Pathname.new(File.dirname(__FILE__))
 ROOT_DIR = SPEC_DIR.join("..")

--- a/stellar_base.gemspec
+++ b/stellar_base.gemspec
@@ -36,10 +36,11 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "stellar-sdk"
+  s.add_development_dependency "stellar-sdk", ">= 0.6.0"
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'vcr', '~> 4.0'
   s.add_development_dependency 'webmock'
   s.add_development_dependency "rspec-sidekiq"
+  s.add_development_dependency "stellar_spectrum", "~> 1.0"
 
 end


### PR DESCRIPTION
This allows for using multiple payment channels to send payments

Currently, apps that use this need to use these gems and branches, until the gems are released:

- https://github.com/bloom-solutions/ruby-stellar-sdk/tree/clarify-payment-channel
- https://github.com/bloom-solutions/stellar_spectrum-ruby/commit/4c9df582da87c65f5dac7cfe5312e1e961518984