### PR TITLE
Add a /balance endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Add `balances` module. Which mounts a `/balance/:asset_code` endpoint that returns the `max_amount` of a withdrawable asset
+
 ## [0.9.6] - 2018-11-07
 ### Fixed
 - `DepositRequests::Trigger` skipping of sending assets when `SendAsset` fails

--- a/app/concepts/stellar_base/balances/balances_policy.rb
+++ b/app/concepts/stellar_base/balances/balances_policy.rb
@@ -1,0 +1,15 @@
+module StellarBase
+  module Balances
+    class BalancesPolicy
+
+      def initialize(_, _)
+      end
+
+      def show?
+        StellarBase.included_module?(:balances) &&
+          StellarBase.included_module?(:withdraw)
+      end
+
+    end
+  end
+end

--- a/app/concepts/stellar_base/balances/contracts/show.rb
+++ b/app/concepts/stellar_base/balances/contracts/show.rb
@@ -1,0 +1,28 @@
+module StellarBase
+  module Balances
+    module Contracts
+      class Create < ApplicationContract
+
+        property :asset_code
+
+        validates :asset_code, presence: true
+        validate :check_valid_asset_code
+
+        def check_valid_asset_code
+          asset_codes = StellarBase.configuration.withdrawable_assets
+            &.map do |asset|
+              asset[:asset_code]
+            end
+
+          return if asset_codes.include? asset_code
+
+          errors.add(
+            :asset_code,
+            "invalid asset_code. Valid asset_codes: #{asset_codes.join(', ')}",
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/app/concepts/stellar_base/balances/contracts/show.rb
+++ b/app/concepts/stellar_base/balances/contracts/show.rb
@@ -1,7 +1,7 @@
 module StellarBase
   module Balances
     module Contracts
-      class Create < ApplicationContract
+      class Show < ApplicationContract
 
         property :asset_code
 

--- a/app/concepts/stellar_base/balances/operations/show.rb
+++ b/app/concepts/stellar_base/balances/operations/show.rb
@@ -1,0 +1,35 @@
+module StellarBase
+  module Balances
+    module Operations
+      class Show < ApplicationOperation
+
+        step self::Policy::Pundit(BalancesPolicy, :show?)
+        failure :set_policy_error!
+        step Model(Balance, :new)
+        step Contract::Build(constant: Contracts::Create)
+        step Contract::Validate(key: :balance)
+        step Contract::Persist(method: :sync)
+        step :find_asset_details!
+        success :set_amount!
+
+        private
+
+        def set_policy_error!(options, params:, **)
+          options["result.policy.message"] = "Not authorized to check balances"
+        end
+
+        def find_asset_details!(options, params:, **)
+          details = WithdrawalRequests::FindWithdrawableAsset
+            .(params[:balance][:asset_code])
+          options[:asset_details] = details.presence || {}
+        end
+
+        def set_amount!(options, asset_details:, params:, **)
+          options["model"].amount = WithdrawalRequests::DetermineMaxAmount
+            .(asset_details[:max_amount_from])
+        end
+
+      end
+    end
+  end
+end

--- a/app/concepts/stellar_base/balances/operations/show.rb
+++ b/app/concepts/stellar_base/balances/operations/show.rb
@@ -5,14 +5,18 @@ module StellarBase
 
         step self::Policy::Pundit(BalancesPolicy, :show?)
         failure :set_policy_error!
-        step Model(Balance, :new)
-        step Contract::Build(constant: Contracts::Create)
+        step :setup_model!
+        step Contract::Build(constant: Contracts::Show)
         step Contract::Validate(key: :balance)
         step Contract::Persist(method: :sync)
         step :find_asset_details!
         success :set_amount!
 
         private
+
+        def setup_model!(options)
+          options["model"] = Balance.new
+        end
 
         def set_policy_error!(options, params:, **)
           options["result.policy.message"] = "Not authorized to check balances"

--- a/app/controllers/stellar_base/balances_controller.rb
+++ b/app/controllers/stellar_base/balances_controller.rb
@@ -1,0 +1,39 @@
+module StellarBase
+  class BalancesController < ApplicationController
+
+    def show
+      op = Balances::Operations::Show.(balance: balance_params)
+
+      respond_to do |f|
+        f.json do
+          if op.success?
+            representer = BalanceRepresenter.new(op["model"])
+            render json: representer
+          else
+            render(
+              json: errors_from(op),
+              status: :unprocessable_entity,
+            )
+          end
+        end
+      end
+    end
+
+    private
+
+    def errors_from(op)
+      unless op["result.policy.default"].success?
+        return { errors: op["result.policy.message"] }
+      end
+
+      if op["contract.default"].errors.any?
+        return { errors: op["contract.default"].errors }
+      end
+    end
+
+    def balance_params
+      params.permit(:asset_code).to_hash.with_indifferent_access
+    end
+
+  end
+end

--- a/app/models/stellar_base/balance.rb
+++ b/app/models/stellar_base/balance.rb
@@ -6,5 +6,12 @@ module StellarBase
     attribute :asset_code, String
     attribute :amount, BigDecimal
 
+    def self.find(asset_code)
+      asset = FindWithdrawableAsset.(asset_code)
+
+      amount = DetermineMaxAmount.(asset[:max_amount_from])
+      new(asset_code: asset_code, amount: amount)
+    end
+
   end
 end

--- a/app/models/stellar_base/balance.rb
+++ b/app/models/stellar_base/balance.rb
@@ -1,0 +1,10 @@
+module StellarBase
+  class Balance
+
+    include Virtus.model
+
+    attribute :asset_code, String
+    attribute :amount, BigDecimal
+
+  end
+end

--- a/app/representers/stellar_base/balance_representer.rb
+++ b/app/representers/stellar_base/balance_representer.rb
@@ -1,0 +1,8 @@
+module StellarBase
+  class BalanceRepresenter < ApplicationRepresenter
+
+    property :asset_code
+    property :amount
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ StellarBase::Engine.routes.draw do
   resources :bridge_callbacks, only: [:create], defaults: { format: "json" }
   get "/withdraw" => "withdraw#create", as: :withdraw
   get "/deposit" => "deposit#create", as: :deposit
+  get "/balance/:asset_code" => "balances#show", as: :balance
 end
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -193,3 +193,9 @@ This engine gives you a method called `StellarBase.on_deposit_trigger` you call 
   - `how_from` is a class that you define that will run whenever a deposit for that asset is requested. It'll populate the `how` response field. If you don't define anything, it won't run that class and will return `nil` for the `how`
     - The `how_from` class is expected a `String` return.
     - The `how_from` class is expected to implement a `self.call` method. You can implement the `self.call` to accept parameters and it'll be passed the request parameters from `GET /deposit`, the parameters will be in a form of a `Hash`
+
+## Balances
+
+Activate this by specifying `balances` in the `modules` configuration.
+
+This will mount the `/balance` endpoint. It returns the `max_amount` of a `withdrawable_asset`. This should be used in conjunction with `withdraw` module.

--- a/spec/concepts/stellar_base/balances/contracts/show_spec.rb
+++ b/spec/concepts/stellar_base/balances/contracts/show_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+module StellarBase
+  module Balances
+    module Contracts
+      RSpec.describe Show do
+        describe "validations" do
+          it "requires #{attr}" do
+            contract = described_class.new(Balance.new)
+            contract.validate(asset_code: "")
+            expect(contract.errors[:asset_code]).to include("can't be blank")
+          end
+
+          context "valid asset_code" do
+            it "requires inclusion in withdrawable_assets" do
+              contract = described_class.new(Balance.new)
+              contract.validate(asset_code: "BTCH")
+              expect(contract.errors[:asset_code])
+                .to include "invalid asset_code. Valid asset_codes: BTCT"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/concepts/stellar_base/balances/operations/show_spec.rb
+++ b/spec/concepts/stellar_base/balances/operations/show_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+module StellarBase
+  module Balances
+    module Operations
+      RSpec.describe Show do
+
+        it "returns a balance object" do
+          op = described_class.(balance: { asset_code: "BTCT" })
+
+          expect(op).to be_success
+
+          expect(op["model"].amount).to eq GetMaxAmount::SAMPLE_MAX_AMOUNT
+          expect(op["model"].asset_code).to eq "BTCT"
+        end
+
+        context "a non-existent asset_code" do
+          it "is not successful" do
+            op = described_class.(balance: { asset_code: "BCHT" })
+
+            expect(op).to_not be_success
+
+            contract = op["contract.default"]
+
+            expect(contract.errors[:asset_code])
+              .to include "invalid asset_code. Valid asset_codes: BTCT"
+          end
+        end
+
+        context "balances module is not loaded" do
+          before do
+            StellarBase.configuration.modules = %i[]
+          end
+
+          it "creates a withdrawal request" do
+            op = described_class.()
+
+            expect(op).to_not be_success
+            expect(op["result.policy.default"]).to_not be_success
+            expect(op["result.policy.message"])
+              .to eq "Not authorized to check balances"
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/representers/stellar_base/balance_representer_spec.rb
+++ b/spec/representers/stellar_base/balance_representer_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+module StellarBase
+  RSpec.describe BalanceRepresenter do
+
+    it "exposes the attributes" do
+      balance = Balance.new(asset_code: "BTCT", amount: 1.5)
+
+      representer = described_class.new(balance)
+      serialized = representer.to_hash.with_indifferent_access
+
+      expect(serialized[:amount]).to eq 1.5
+      expect(serialized[:asset_code]).to eq "BTCT"
+    end
+
+  end
+end

--- a/spec/requests/balances_spec.rb
+++ b/spec/requests/balances_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe "GET /balance", type: :request do
+  let(:uri) do
+    StellarBase::Engine.routes.url_helpers.balance_path(asset_code)
+  end
+
+  context "balance for an asset" do
+    let(:asset_code) { "BTCT" }
+    let(:json_response) do
+      get(uri, params: { format: :json })
+
+      expect(response).to be_successful
+      JSON.parse(response.body).with_indifferent_access
+    end
+
+    it "executes the given instructions" do
+      expect(json_response[:asset_code]).to eq "BTCT"
+      expect(json_response[:amount]).to eq "1.0"
+    end
+  end
+
+  context "requesting withdrawal details for an invalid asset" do
+    let(:asset_code) { "BCHT" }
+
+    it "returns an error" do
+      get(uri, params: { format: :json })
+
+      expect(response).not_to be_successful
+      json = JSON.parse(response.body).with_indifferent_access
+
+      expect(json["errors"]).to be_present
+      expect(json["errors"]["asset_code"])
+        .to include "invalid asset_code. Valid asset_codes: BTCT"
+    end
+  end
+
+  context "requesting withdrawal details without the `withdraw` module" do
+    let(:asset_code) { "BCHT" }
+
+    before do
+      StellarBase.configuration.modules = %w[bridge_callbacks]
+    end
+
+    it "denies access" do
+      get(uri, params: { format: :json })
+
+      expect(response).not_to be_successful
+      json = JSON.parse(response.body).with_indifferent_access
+
+      expect(json["errors"]).to be_present
+      expect(json["errors"]).to eq "Not authorized to check balances"
+    end
+  end
+end

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -10,7 +10,7 @@ RSpec.configure do |c|
       c.check_bridge_callbacks_mac_payload = false
       c.distribution_account = "G-DISTRO-ACCOUNT"
       c.horizon_url = "https://horizon-testnet.stellar.org"
-      c.modules = %i[bridge_callbacks withdraw deposit]
+      c.modules = %i[bridge_callbacks withdraw deposit balances]
       c.on_bridge_callback = "ProcessBridgeCallback"
       c.on_withdraw = ProcessWithdrawal.to_s
       c.stellar_toml = { TRANSFER_SERVER: "http://example.com/stellar" }


### PR DESCRIPTION
This PR adds a `balances` module. Used in conjunction with the `withdraw` module. It exposes a `/balance/:asset_code` API endpoint that returns the `max_amount` of a withdrawable asset.