### PR TITLE
Multiple fixes:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Save cursor right after fetching when an account subscription has none
+- Assign operation to `raw` and let Virtus assign the rest lazily
+
 ## [1.1.1] - 2018-12-15
 ### Fixed
 - AccountSubscriptions properly use cursor

--- a/app/services/stellar_base/account_subscriptions/get_cursor.rb
+++ b/app/services/stellar_base/account_subscriptions/get_cursor.rb
@@ -13,10 +13,11 @@ module StellarBase
 
         address = c.account_subscription.address
 
-        c.cursor = c.stellar_sdk_client.horizon
-          .account(account_id: address)
-          .operations(order: "desc", limit: 1).records.first.id
+        c.cursor = c.stellar_sdk_client.horizon.
+          account(account_id: address).
+          operations(order: "desc", limit: 1).records.first.id
 
+        c.account_subscription.update_attributes!(cursor: c.cursor)
       rescue Faraday::ClientError => e
         c.fail_and_return! "Skipping fetching cursor of #{address} " \
           "due to #{e.inspect}"

--- a/app/services/stellar_base/account_subscriptions/get_tx.rb
+++ b/app/services/stellar_base/account_subscriptions/get_tx.rb
@@ -9,7 +9,7 @@ module StellarBase
       executed do |c|
         hash = c.operation.transaction_hash
         tx_json = c.stellar_sdk_client.horizon.transaction(hash: hash)
-        c.tx = StellarTransaction.new(tx_json)
+        c.tx = StellarTransaction.new(raw: tx_json)
       end
 
     end

--- a/spec/services/stellar_base/account_subscriptions/get_cursor_spec.rb
+++ b/spec/services/stellar_base/account_subscriptions/get_cursor_spec.rb
@@ -54,6 +54,7 @@ module StellarBase
           )
 
           expect(resulting_ctx.cursor).to be_present
+          expect(account_subscription.cursor).to eq resulting_ctx.cursor
         end
       end
     end

--- a/spec/services/stellar_base/account_subscriptions/get_tx_spec.rb
+++ b/spec/services/stellar_base/account_subscriptions/get_tx_spec.rb
@@ -16,6 +16,7 @@ module StellarBase
           operation: operation,
           stellar_sdk_client: client,
         })
+        expect(resulting_ctx.tx.raw.fee_paid).to eq 100
         expect(resulting_ctx.tx.fee_paid).to eq 100
       end
 


### PR DESCRIPTION
- Save cursor right after fetching when an account subscription has none
- Assign operation to `raw` and let Virtus assign the rest lazily